### PR TITLE
Membership Record Status - Not updating based on dates

### DIFF
--- a/wicket.php
+++ b/wicket.php
@@ -230,8 +230,12 @@ if ( ! class_exists( 'Wicket_Memberships' ) ) {
       //these will expire memberships that have not been renewed at end of grace period
       add_action('wp', array( $this, 'schedule_daily_membership_expiry'), 10, 2);
       add_action('schedule_daily_membership_expiry_hook', array( __NAMESPACE__.'\\Membership_Controller', 'daily_membership_expiry_hook'), 10, 2);
-      //these will set to garce_period memberships that have not been renewed at membership_ends_at date
+      //these will set to grace_period memberships that have not been renewed at membership_ends_at date
       add_action('wp', array($this, 'schedule_daily_membership_grace_period'), 10, 2);
+      add_action('schedule_daily_membership_grace_period_hook', array( __NAMESPACE__.'\\Membership_Controller', 'daily_membership_grace_period_hook'), 10, 2);
+      //these will activate delayed memberships once their membership_starts_at date has been reached
+      add_action('wp', array($this, 'schedule_daily_membership_activation'), 10, 2);
+      add_action('schedule_daily_membership_activation_hook', array( __NAMESPACE__.'\\Membership_Controller', 'daily_membership_activation_hook'), 10, 2);
       
       //checkbox toggle - can be used for view subscriptions
       add_action('init', [__NAMESPACE__.'\\Utilities', 'autorenew_checkbox_toggle_switch']);
@@ -252,6 +256,15 @@ if ( ! class_exists( 'Wicket_Memberships' ) ) {
         $next_run_time = new \DateTime('tomorrow 3:30', $timezone);
         $next_run_time->setTimezone(new \DateTimeZone('UTC'));
         as_schedule_recurring_action($next_run_time->getTimestamp(), DAY_IN_SECONDS, 'schedule_daily_membership_grace_period_hook');
+      }
+    }
+
+    public static function schedule_daily_membership_activation() {
+      if (!as_next_scheduled_action('schedule_daily_membership_activation_hook')) {
+        $timezone = wp_timezone();
+        $next_run_time = new \DateTime('tomorrow 4:00', $timezone);
+        $next_run_time->setTimezone(new \DateTimeZone('UTC'));
+        as_schedule_recurring_action($next_run_time->getTimestamp(), DAY_IN_SECONDS, 'schedule_daily_membership_activation_hook');
       }
     }
 


### PR DESCRIPTION
https://app.asana.com/1/1138832104141584/project/1213180954049510/task/1213270711660691

## Problem

  Membership record statuses were not automatically updating as membership dates were reached. Three transitions were either broken or missing:

  - Delayed → Active — no daily hook existed for this transition at all
  - Active → Grace Period — the daily hook method existed but its action handler was never registered in wicket.php, so the scheduled job ran but did nothing
  - Active / Grace Period → Expired — this was already working correctly

  Note: The primary mechanism for Delayed → Active transitions on renewals is the expire_old_membership_on_new_starts_at single scheduled action created at membership
  creation time. This new daily hook acts as a catch-all fallback for cases where that doesn't fire as expected.
  
   ## Changes

  includes/Membership_Controller.php
  - Added daily_membership_activation_hook() — finds all delayed memberships whose membership_starts_at has passed and sets them to active
  - Removed redundant membership_status != grace_period condition from daily_membership_grace_period_hook() meta query (was already covered by the = active condition)

  wicket.php
  - Registered the missing add_action('schedule_daily_membership_grace_period_hook', ...) handler
  - Added scheduling (schedule_daily_membership_activation) and action handler registration for the new activation hook, running daily at 4:00am

  includes/Settings.php
  - Added get_next_scheduled_membership_activation() to surface next run time in admin
  - Added "Run Now" support for the activation hook
  - Updated the Membership Status Changes section to display all three scheduled jobs with clear transition labels
  
   ## Testing

  ### Set up conditions for Delayed → Active test
  wp eval "
  update_post_meta( POST_ID, 'membership_status', 'delayed' );
  \$yesterday = (new DateTime('yesterday', wp_timezone()))->format('Y-m-d\TH:i:sP');
  update_post_meta( POST_ID, 'membership_starts_at', \$yesterday );
  "
  ### Then run via WooCommerce > Status > Scheduled Actions or:
  wp eval "Wicket_Memberships\Membership_Controller::daily_membership_activation_hook();"
  wp eval "echo get_post_meta( POST_ID, 'membership_status', true );" # expect: active

  ### Set up conditions for Active → Grace Period test
  wp eval "
  update_post_meta( POST_ID, 'membership_status', 'active' );
  \$yesterday = (new DateTime('yesterday', wp_timezone()))->format('Y-m-d\TH:i:sP');
  update_post_meta( POST_ID, 'membership_ends_at', \$yesterday );
  "
  wp eval "Wicket_Memberships\Membership_Controller::daily_membership_grace_period_hook();"
  wp eval "echo get_post_meta( POST_ID, 'membership_status', true );" # expect: grace_period
