### PR TITLE
Feature/users multi tier renewal subscriptions merged sync tool

### DIFF
--- a/custom/memberships-sync.php
+++ b/custom/memberships-sync.php
@@ -27,13 +27,25 @@ function wicket_action_woocommerce_loaded() {
   }
 }
 
+/**
+ * Reconciles WooCommerce membership subscriptions with their plugin membership records.
+ *
+ * Triggered by the `?mship_subscription_sync=1` browser request. Walks active/on-hold
+ * subscriptions, maps each line-item product to a Membership Tier, finds the matching
+ * membership for the subscriber, and links the subscription/order/product meta back to it
+ * (and syncs MDP seat counts for per-seat organization tiers). All output is streamed to
+ * the screen inside a <pre> block as a human-readable, grouped-per-record log.
+ *
+ * Runs as a dry-run by default; add `no_debug=1` to write changes. Supported request args:
+ * `count_only`, `subscription_to_update`, `page_number`, `page_length`, `created_after`.
+ *
+ * @return void Output is echoed directly; the request is terminated with die().
+ */
 function wicket_sync_subscriptions() {
   echo "<pre>";
-  //for product mapping
-  if (defined('WP_ENVIRONMENT_TYPE')) {
-    $wp_env_type = WP_ENVIRONMENT_TYPE;
-    echo $wp_env_type."\n<BR>";
-  }
+
+  // Read and normalise the run parameters before emitting the summary so the operator
+  // can confirm scope/mode at the top of the output before scanning per-record results.
   $subscription_to_update = !empty($_REQUEST['subscription_to_update']) ? $_REQUEST['subscription_to_update'] : '';
   $page_number = !empty($_REQUEST['page_number']) ? $_REQUEST['page_number'] : 1;
   $page_length = !empty($_REQUEST['page_length']) ? $_REQUEST['page_length'] : 100;
@@ -42,6 +54,19 @@ function wicket_sync_subscriptions() {
   $count_only = !empty($_REQUEST['count_only']) ? true : false;
 
   $log = [];
+
+  // Run summary header — describes what this invocation is going to do.
+  echo "<strong>Wicket Membership Subscription Sync</strong>\n";
+  if (defined('WP_ENVIRONMENT_TYPE')) {
+    echo "Environment: " . WP_ENVIRONMENT_TYPE . "\n";
+  }
+  echo "Mode: " . ($count_only ? "Count only (no changes)" : ($debug ? "DEBUG dry run — no changes will be written (add no_debug=1 to apply)" : "LIVE — changes will be written")) . "\n";
+  if (!empty($subscription_to_update)) {
+    echo "Scope: single subscription #{$subscription_to_update}\n";
+  } else {
+    echo "Scope: page {$page_number} ({$page_length} per page)" . (!empty($created_after) ? ", created on/after {$created_after}" : "") . "\n";
+  }
+  echo str_repeat("=", 60) . "\n";
 
   //get all subscriptions for page_number by page_length
 
@@ -73,8 +98,8 @@ function wicket_sync_subscriptions() {
       }
     }
 
-    echo 'Total Active Subscriptions: '.count($subscription_ids)."\n<BR>";
-    echo 'Subscriptions with Membership Products: '.count($membership_subscriptions)."\n<BR>";
+    echo "Total active/on-hold subscriptions: " . count($subscription_ids) . "\n";
+    echo "Subscriptions containing membership products: " . count($membership_subscriptions) . "\n";
     die();
   }
   if(!empty($subscription_to_update)) {
@@ -93,34 +118,39 @@ function wicket_sync_subscriptions() {
   }
 
   if($debug) {
-    echo 'DEBUG'."\n<BR>";;
     //var_dump($argv,$subscription_to_update);
   } else {
+    // Only initialise the live MDP API client when we intend to write changes.
     $wicket_api_client = wicket_api_client();
   }
 
-  $cnt=0;
+  $cnt = 0;
+  // Total drives the "Record X of Y" header so the operator can gauge progress through the batch.
+  $total = count($subscriptions);
   foreach ($subscriptions as $sub_post) {
     $sub = wcs_get_subscription( $sub_post->ID );
-      $cnt++;
-      echo " $cnt: <br>";
+    $cnt++;
+
+    // Begin a visually distinct block for this subscription record.
+    echo "\n" . str_repeat("-", 60) . "\n";
+    echo "Record {$cnt} of {$total} — Subscription #{$sub->ID}\n";
 
     //get user and email from subscription
     $user_id = $sub->get_user_id();
     if(empty($user_id)) {
       $log[] = 'Failed Sub ID:' . $sub->ID . ' | User Missing';
-      echo 'Failed Sub ID:' . $sub->ID . ' | User Missing' . "\n<br>";
+      echo "  Skipped — no user is associated with this subscription.\n";
       continue;
     }
     $user = get_user_by('id', $user_id);
     if (empty($user)) {
       $log[] = 'Failed Sub ID:' . $sub->ID . ' | User Missing';
-      echo 'Failed Sub ID:' . $sub->ID . ' | User Missing' . "\n<br>";
+      echo "  Skipped — user #{$user_id} no longer exists.\n";
       continue;
     }
 
     $log[] = 'New Sub ID:' . $sub->ID . ' | User ID: ' . $user->ID . ' | User Email: ' . $user->user_email;
-    echo 'New Sub ID:' . $sub->ID . ' | User ID: ' . $user->ID . ' | User Email: ' . $user->user_email . "\n<br>";
+    echo "  User #{$user->ID} ({$user->user_email})\n";
 
     $subscription_items = $sub->get_items();
     foreach($subscription_items as $item_id => $item) {
@@ -134,17 +164,23 @@ function wicket_sync_subscriptions() {
         //the subscriptions will have the old products attached and the Tiers have the new ones required for lookup
         $mapped_product_id = wicket_get_mapped_product_id_for_tier( $product_id);
 
+        // Item-level header groups all output for this line item under the subscription record.
+        // Show the product remap explicitly when the stored product differs from the tier's product.
+        $product_label = "“{$product_name}” (product #{$product_id}";
+        $product_label .= ($mapped_product_id != $product_id) ? " → mapped to #{$mapped_product_id})" : ")";
+        echo "  Item: {$product_label}\n";
+
         $Tier = \Wicket_Memberships\Membership_Tier::get_tier_by_product_id($mapped_product_id);
         if(empty($Tier)) {
           $product_name = $item->get_name();
           $log[] = 'No mapped tier for new product ('.$product_name.') ID: ' . $mapped_product_id ;
-          echo '<span style="color:red">No mapped tier ID for new product ('.$product_name.') ID:</span> ' . $mapped_product_id."\n<br>";
+          echo "    <span style=\"color:red\">No Tier maps to product #{$mapped_product_id} — skipping item.</span>\n";
           continue;
         }
         $tier_id = $Tier->get_membership_tier_post_id();
         if(empty($tier_id)) {
           $log[] = 'No tier postID found for new product ID: ' . $mapped_product_id;
-          echo 'No tier postID found for new product ID: ' . $mapped_product_id . "\n<br>";
+          echo "    <span style=\"color:red\">Tier for product #{$mapped_product_id} has no post ID — skipping item.</span>\n";
           continue; //entry not mapped to a tier
         }
 
@@ -171,20 +207,22 @@ function wicket_sync_subscriptions() {
         //update meta on membership if found
         if (empty($user_memberships)) {
           $log[] = 'No Membership found for User ID ' . $user_id . ' on Tier ID ' . $tier_id . ' for productID: ' . $mapped_product_id;
-          echo '<span style="color:red">No Membership found for User ID ' . $user_id . ' on Tier ID ' . $tier_id  . ' for productID: ' . $mapped_product_id . " with Product Name: <u>" . $product_name . "</u>" .  "</span>\n<br>";
+          echo "    <span style=\"color:red\">No membership found for user #{$user_id} on Tier #{$tier_id} — skipping item.</span>\n";
           continue;
         }
           $log[] = 'Found Membership ( ID: '.$user_memberships[0]->ID.' ) for User ID ' . $user_id . ' on Tier ID ' . $tier_id;
-          echo 'Found '.count($user_memberships). 'Membership <a target="_blank" href="/wp/wp-admin/post.php?action=edit&post='.$user_memberships[0]->ID.'"> '.$user_memberships[0]->ID.'</a>for User ID ' . $user_id . ' on Tier ID ' . $tier_id . "with Product Name: <u>" . $product_name . "</u> (ID: " . $mapped_product_id . ")\n";
+          // Note when more than one membership matches; only the first is linked.
+          $match_note = count($user_memberships) > 1 ? " (" . count($user_memberships) . " matched, using first)" : "";
+          echo "    Matched membership <a target=\"_blank\" href=\"/wp/wp-admin/post.php?action=edit&post={$user_memberships[0]->ID}\">#{$user_memberships[0]->ID}</a> on Tier #{$tier_id}.{$match_note}\n";
 
           $meta_check = wc_get_order_item_meta( $item_id, '_membership_post_id_renew', true);
           if(!empty($meta_check)) {
             $log[] = 'ITEM Meta _membership_post_id_renew ALREADY SET to '.$meta_check;
-            echo '<span style="color:blue">ITEM Meta _membership_post_id_renew ALREADY SET to '.$meta_check."</span>\n<br>";
+            echo "    <span style=\"color:blue\">Renewal link already set (_membership_post_id_renew = {$meta_check}) — skipping item.</span>\n";
             continue;
           } else {
             $log[] = 'ITEM Meta _membership_post_id_renew NOT SET or NOT EQUAL to membership ID '.$user_memberships[0]->ID;
-            echo '<span style="color:green;font-weight:bold;">ITEM Meta _membership_post_id_renew NOT SET or NOT EQUAL to membership ID '.$user_memberships[0]->ID."</span>\n<br>";
+            echo "    <span style=\"color:green;font-weight:bold;\">Renewal link not set — will link to membership #{$user_memberships[0]->ID}.</span>\n";
           }
           //var_dump($user_memberships);
           //var_dump(get_post_meta($user_memberships[0]->ID));exit;
@@ -195,14 +233,15 @@ function wicket_sync_subscriptions() {
             update_post_meta($user_memberships[0]->ID, 'membership_product_id', $mapped_product_id);
             update_post_meta($user_memberships[0]->ID, 'membership_subscription_id', $sub->ID);
             update_post_meta($user_memberships[0]->ID, 'membership_parent_order_id', $sub->get_parent_id());
+            echo "    <span style=\"color:green\">Updated membership #{$user_memberships[0]->ID} meta — product #{$mapped_product_id}, subscription #{$sub->ID}, order #{$sub->get_parent_id()}.</span>\n";
             //add the membership post_id to support subscription renewaitem_idl flow (only) in subscription item meta
             if(empty(wc_get_order_item_meta( $item_id, '_membership_post_id_renew', true)) && !empty($user_memberships[0]->ID)) {
               wc_add_order_item_meta( $item_id, '_membership_post_id_renew', $user_memberships[0]->ID, true );
               $log[] = 'ITEM Meta _membership_post_id_renew Set to '.$user_memberships[0]->ID;
-              echo 'ITEM Meta _membership_post_id_renew Set to '.$user_memberships[0]->ID."\n<br>";
+              echo "    <span style=\"color:green\">Linked subscription item to membership #{$user_memberships[0]->ID} (_membership_post_id_renew).</span>\n";
             } else {
               $log[] = 'ITEM Meta _membership_post_id_renew ALREADY SET to '.wc_get_order_item_meta( $item_id, '_membership_post_id_renew', true);
-              echo 'ITEM Meta _membership_post_id_renew ALREADY SET to '.wc_get_order_item_meta( $item_id, '_membership_post_id_renew', true)."\n<br>";
+              echo "    <span style=\"color:blue\">Renewal link already set to " . wc_get_order_item_meta( $item_id, '_membership_post_id_renew', true ) . ".</span>\n";
             }
           }
           //update membership json from post data
@@ -212,17 +251,17 @@ function wicket_sync_subscriptions() {
           if($Tier->is_organization_tier() && $Tier->is_per_seat() && (!empty($wicket_api_client) || !empty($debug))) {
             $quantity = $item->get_quantity();
             $log[] = 'Organization Tier - Syncing MDP Seats to Subscription Item with Product: ' . $product_name . ' and Quantity: '.$quantity;
-            echo 'Organization Tier - Syncing MDP Seats to Subscription Item with Product: ' . $product_name . ' and Quantity: '.$quantity."\n<br>";
+            echo "    Organization tier — syncing {$quantity} seat(s) to MDP from item quantity.\n";
             if(empty($debug)) {
               $wicket_membership_uuid = get_post_meta($user_memberships[0]->ID, 'membership_wicket_uuid', true);
               update_post_meta($user_memberships[0]->ID, 'org_seats', $quantity);
               $updated = memberships_update_seat_count( $wicket_api_client, $wicket_membership_uuid, $quantity);
               if(is_wp_error($updated)) {
                 $log[] = 'Error updating MDP Seats via API: ' . $updated->get_error_message();
-                echo '<span style="color:red">Error updating MDP Seats via API: ' . $updated->get_error_message() . '</span>'."\n<br>";
+                echo "      <span style=\"color:red\">Error updating MDP seats via API: " . $updated->get_error_message() . "</span>\n";
               } else {
                 $log[] = 'MDP Seats updated to '.$quantity;
-                echo 'MDP Seats updated to '.$quantity."\n<br>";
+                echo "      <span style=\"color:green\">MDP seats updated to {$quantity}.</span>\n";
               }
             }
           }
@@ -266,6 +305,20 @@ function wicket_get_mapped_product_id_for_tier( $product_id ) {
     return $product_id;
 }
 
+/**
+ * Rebuilds and stores the membership JSON blob across order, subscription, and user meta.
+ *
+ * Flattens the membership post meta into a single record, overlays the incoming IDs
+ * (product/subscription/order), regenerates the membership JSON, and writes it to the
+ * parent order meta, the subscription meta, and the subscriber's user meta. In debug mode
+ * it instead dumps the would-be JSON to the screen and writes nothing.
+ *
+ * @param  int    $post_id             Membership CPT post ID to rebuild the JSON for.
+ * @param  bool|int $debug             When truthy, preview only — no meta is written.
+ * @param  array  $membership_incoming Incoming overrides (product/subscription/order IDs).
+ *
+ * @return string|void  The encoded user-meta JSON on a live write; nothing on debug preview.
+ */
 function wicket_update_membership_json_data( $post_id, $debug = 0, $membership_incoming = []) {
 
   $membership_meta = get_post_meta( $post_id );
@@ -287,9 +340,21 @@ function wicket_update_membership_json_data( $post_id, $debug = 0, $membership_i
   $membership_json = \Wicket_Memberships\Helper::get_membership_json_from_membership_post_data( $membership );
 
   if($debug) {
-    echo 'JSON Updated:<br><pre>';
+    // Dry-run: capture (don't echo) the JSON that would be written so it can be shown on
+    // demand instead of flooding the log; var_dump writes to output, so buffer it.
+    ob_start();
     var_dump($membership_json);
-    echo '</pre><br>';
+    $json_preview = ob_get_clean();
+
+    // Unique id per preview so multiple records on one page toggle independently.
+    static $preview_seq = 0;
+    $preview_id = 'wmsync-json-' . (++$preview_seq);
+
+    // Render a small clickable icon that toggles the hidden JSON block; collapsed by default
+    // to keep the per-record log readable. Inline onclick avoids a separate script per block.
+    echo "    Membership JSON preview (not written in debug mode) ";
+    echo "<a href=\"#\" title=\"Show/hide JSON\" style=\"text-decoration:none;\" onclick=\"var e=document.getElementById('{$preview_id}');e.style.display=(e.style.display==='none'?'block':'none');return false;\">&#128269;</a>\n";
+    echo "<span id=\"{$preview_id}\" style=\"display:none;margin-left:2em;\">" . htmlspecialchars($json_preview) . "</span>";
     return;
   }
 

--- a/custom/memberships-sync.php
+++ b/custom/memberships-sync.php
@@ -42,16 +42,69 @@ function wicket_action_woocommerce_loaded() {
  * @return void Output is echoed directly; the request is terminated with die().
  */
 function wicket_sync_subscriptions() {
-  echo "<pre>";
-
-  // Read and normalise the run parameters before emitting the summary so the operator
-  // can confirm scope/mode at the top of the output before scanning per-record results.
-  $subscription_to_update = !empty($_REQUEST['subscription_to_update']) ? $_REQUEST['subscription_to_update'] : '';
-  $page_number = !empty($_REQUEST['page_number']) ? $_REQUEST['page_number'] : 1;
-  $page_length = !empty($_REQUEST['page_length']) ? $_REQUEST['page_length'] : 100;
-  $created_after = !empty($_REQUEST['created_after']) ? $_REQUEST['created_after'] : ''; //format YYYY-MM-DD
+  // Sanitise the request parameters — they arrive raw from the URL/control bar.
+  // A single subscription id is treated as an int; 0/invalid means "batch mode".
+  $subscription_to_update = isset($_REQUEST['subscription_to_update']) ? (int) $_REQUEST['subscription_to_update'] : 0;
+  $subscription_to_update = $subscription_to_update > 0 ? (string) $subscription_to_update : '';
+  $page_number = isset($_REQUEST['page_number']) ? max(1, (int) $_REQUEST['page_number']) : 1;
+  $page_length = isset($_REQUEST['page_length']) ? (int) $_REQUEST['page_length'] : 100;
+  // Constrain page length to the values offered in the control bar to avoid runaway queries.
+  if (!in_array($page_length, [25, 50, 100, 200], true)) {
+    $page_length = 100;
+  }
+  // Accept a created-after floor only when it is a valid YYYY-MM-DD date; otherwise ignore it.
+  $created_after = '';
+  if (!empty($_REQUEST['created_after']) && preg_match('/^\d{4}-\d{2}-\d{2}$/', $_REQUEST['created_after'])) {
+    $created_after = $_REQUEST['created_after'];
+  }
+  // LIVE mode is opt-in only: debug stays true unless the control bar explicitly sends no_debug.
   $debug = empty($_REQUEST['no_debug']) ? true : false;
   $count_only = !empty($_REQUEST['count_only']) ? true : false;
+
+  // Only the control bar's buttons set this marker; a bare page load lacks it. We use it to
+  // distinguish "operator clicked Run/Count/Prev/Next" from "just landed on the page", so a
+  // plain load shows the form and runs nothing.
+  $action_requested = !empty($_REQUEST['wmsync_run']);
+
+  // Lightweight count so the control bar can show position within the total — but only once an
+  // action has been requested (the bare landing must run nothing). Uses IDs only (no per-
+  // subscription loading); the heavier membership-product breakdown stays behind "Count Only".
+  $pagination_total = 0;
+  $total_pages = 1;
+  if ($action_requested && $subscription_to_update === '' && !$count_only) {
+    $count_args = [
+      'status' => ['active', 'on-hold'],
+      'return' => 'ids',
+      'subscriptions_per_page' => -1,
+    ];
+    if (!empty($created_after)) {
+      $count_args['date_created'] = '>=' . $created_after;
+    }
+    $pagination_total = count(wcs_get_subscriptions($count_args));
+    $total_pages = max(1, (int) ceil($pagination_total / $page_length));
+    // Clamp a page request that overshoots the available pages back to the last valid page.
+    if ($page_number > $total_pages) {
+      $page_number = $total_pages;
+    }
+  }
+
+  // Render the interactive control bar (plain HTML) above the streamed <pre> log.
+  wicket_sync_render_control_bar([
+    'subscription_to_update' => $subscription_to_update,
+    'page_number'            => $page_number,
+    'page_length'            => $page_length,
+    'created_after'          => $created_after,
+    'pagination_total'       => $pagination_total,
+    'total_pages'            => $total_pages,
+    'action_requested'       => $action_requested,
+  ]);
+
+  // Bare page load: show the form to get started and run nothing else.
+  if (!$action_requested) {
+    die();
+  }
+
+  echo "<pre>";
 
   $log = [];
 
@@ -60,11 +113,14 @@ function wicket_sync_subscriptions() {
   if (defined('WP_ENVIRONMENT_TYPE')) {
     echo "Environment: " . WP_ENVIRONMENT_TYPE . "\n";
   }
-  echo "Mode: " . ($count_only ? "Count only (no changes)" : ($debug ? "DEBUG dry run — no changes will be written (add no_debug=1 to apply)" : "LIVE — changes will be written")) . "\n";
+  echo "Mode: " . ($count_only ? "Count only (no changes)" : ($debug ? "DEBUG dry run — no changes will be written (switch to LIVE in the control bar to apply)" : "LIVE — changes will be written")) . "\n";
   if (!empty($subscription_to_update)) {
     echo "Scope: single subscription #{$subscription_to_update}\n";
   } else {
-    echo "Scope: page {$page_number} ({$page_length} per page)" . (!empty($created_after) ? ", created on/after {$created_after}" : "") . "\n";
+    // Show position within the total so the operator knows where they are in the batch.
+    $range_start = $pagination_total > 0 ? (($page_number - 1) * $page_length) + 1 : 0;
+    $range_end = min($page_number * $page_length, $pagination_total);
+    echo "Scope: page {$page_number} of {$total_pages} — records {$range_start}–{$range_end} of {$pagination_total} ({$page_length} per page)" . (!empty($created_after) ? ", created on/after {$created_after}" : "") . "\n";
   }
   echo str_repeat("=", 60) . "\n";
 
@@ -272,6 +328,173 @@ function wicket_sync_subscriptions() {
     } // end foreach item
   } //end foreach subscription
   die();
+}
+
+/**
+ * Renders the sync tool's interactive control bar above the streamed <pre> log.
+ *
+ * Emits a GET form that re-submits to the current URL with pagination, date, scope, and
+ * run-mode controls, pre-filled from the current request. Safety model:
+ *  - The dry/live radio always defaults to "dry" on every load (LIVE is never persisted),
+ *    so writes are an explicit, per-run decision.
+ *  - Submitting LIVE requires both selecting the LIVE radio AND ticking the confirm box;
+ *    this is enforced client-side before the form is allowed to submit no_debug=1.
+ *  - Prev, Next, and Count Only always submit as a dry run regardless of the radio, so
+ *    navigation and counting can never write data.
+ *
+ * @param array $state {
+ *   Normalised request state and computed pagination figures.
+ *
+ *   @type string $subscription_to_update  Single subscription id, or '' for batch mode.
+ *   @type int    $page_number             Current (clamped) page number.
+ *   @type int    $page_length             Records per page.
+ *   @type string $created_after           YYYY-MM-DD floor, or '' when unset.
+ *   @type int    $pagination_total        Total subscriptions in the paginated set.
+ *   @type int    $total_pages             Total pages for the current page length.
+ * }
+ *
+ * @global void   No globals; reads $_SERVER['REQUEST_URI'] for the form action.
+ * @return void   Outputs HTML directly.
+ */
+function wicket_sync_render_control_bar( array $state ) {
+  // Re-submit to the same path (query string is rebuilt from the form fields).
+  $action = esc_url( strtok( $_SERVER['REQUEST_URI'], '?' ) );
+
+  $single  = $state['subscription_to_update'];
+  $page    = (int) $state['page_number'];
+  $len     = (int) $state['page_length'];
+  $created = $state['created_after'];
+  $total   = (int) $state['pagination_total'];
+  $pages   = (int) $state['total_pages'];
+  // False on a bare landing — totals haven't been queried yet, so show a hint not "0 of 0".
+  $action_requested = !empty( $state['action_requested'] );
+
+  // 1-based record range shown beside the pager, clamped to the total.
+  $range_start = $total > 0 ? ( ( $page - 1 ) * $len ) + 1 : 0;
+  $range_end   = min( $page * $len, $total );
+
+  // In single-subscription scope the pager and date are ignored, so dim that section.
+  $is_batch       = ( $single === '' );
+  $prev_disabled  = ( $page <= 1 )     ? 'disabled' : '';
+  $next_disabled  = ( $page >= $pages ) ? 'disabled' : '';
+  $batch_opacity  = $is_batch ? '1' : '0.4';
+
+  // Page-length dropdown options, current value pre-selected.
+  $len_options = '';
+  foreach ( [ 25, 50, 100, 200 ] as $opt ) {
+    $len_options .= '<option value="' . $opt . '" ' . selected( $opt, $len, false ) . '>' . $opt . '</option>';
+  }
+
+  $env = defined( 'WP_ENVIRONMENT_TYPE' ) ? esc_html( WP_ENVIRONMENT_TYPE ) : '';
+  $created_attr = esc_attr( $created );
+  $single_attr  = esc_attr( $single );
+
+  ?>
+  <div style="font-family:-apple-system,Segoe UI,Roboto,sans-serif;border:1px solid #ccd0d4;background:#fff;padding:14px 16px;margin:0 0 12px;max-width:900px;">
+    <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px;">
+      <strong style="font-size:14px;">Wicket Membership Subscription Sync</strong>
+      <?php if ( $env ) : ?><span style="color:#666;font-size:12px;">env: <?php echo $env; ?></span><?php endif; ?>
+    </div>
+
+    <form id="wmsync-form" method="get" action="<?php echo $action; ?>">
+      <?php // Persist the trigger and the run-mode flags (set by the buttons via JS). ?>
+      <input type="hidden" name="mship_subscription_sync" value="1" />
+      <input type="hidden" id="wmsync-no_debug" name="no_debug" value="" />
+      <input type="hidden" id="wmsync-count_only" name="count_only" value="" />
+      <input type="hidden" id="wmsync-page" name="page_number" value="<?php echo $page; ?>" />
+      <?php // Set to 1 by every action button; absent on a bare load so the server runs nothing. ?>
+      <input type="hidden" id="wmsync-run" name="wmsync_run" value="" />
+
+      <div style="opacity:<?php echo $batch_opacity; ?>;margin-bottom:8px;">
+        <label>Created after
+          <input type="date" id="wmsync-created" name="created_after" value="<?php echo $created_attr; ?>" />
+        </label>
+        <a href="#" title="Clear date" style="text-decoration:none;margin-right:14px;"
+           onclick="document.getElementById('wmsync-created').value='';return false;">&#10005;</a>
+        <label style="margin-left:6px;">Per page
+          <?php // Changing page length resets to page 1 so the offset stays meaningful. ?>
+          <select name="page_length" onchange="document.getElementById('wmsync-page').value=1;">
+            <?php echo $len_options; ?>
+          </select>
+        </label>
+      </div>
+
+      <div style="margin-bottom:8px;">
+        <label>Single subscription ID
+          <input type="text" name="subscription_to_update" value="<?php echo $single_attr; ?>" size="10" />
+        </label>
+        <span style="color:#666;font-size:12px;">&larr; overrides pagination &amp; date</span>
+      </div>
+
+      <div style="opacity:<?php echo $batch_opacity; ?>;margin:10px 0;display:flex;align-items:center;gap:10px;">
+        <button type="button" onclick="wmsyncSubmit('count');">&#128290; Count Only</button>
+        <span style="border-left:1px solid #ddd;height:18px;"></span>
+        <button type="button" <?php echo $prev_disabled; ?> onclick="wmsyncPage(-1);">&#9664; Prev</button>
+        <span style="font-size:13px;"><?php
+          // Totals are only known after a run/count; before that, prompt the operator.
+          if ( $action_requested ) {
+            echo 'Page ' . $page . ' of ' . $pages . ' &middot; records ' . $range_start . '&ndash;' . $range_end . ' of ' . $total;
+          } else {
+            echo '<em style="color:#666;">Run or Count to load totals</em>';
+          }
+        ?></span>
+        <button type="button" <?php echo $next_disabled; ?> onclick="wmsyncPage(1);">Next &#9654;</button>
+      </div>
+
+      <div style="border-top:1px solid #eee;padding-top:10px;display:flex;align-items:center;gap:16px;flex-wrap:wrap;">
+        <span>Mode:</span>
+        <?php // Radio ALWAYS defaults to dry on load — LIVE is never pre-selected from the request. ?>
+        <label><input type="radio" name="wmsync_mode" value="dry" checked onchange="wmsyncModeChange();" /> Dry run</label>
+        <label><input type="radio" name="wmsync_mode" value="live" onchange="wmsyncModeChange();" /> <span style="color:#b32d2e;font-weight:bold;">LIVE</span></label>
+        <label style="color:#b32d2e;"><input type="checkbox" id="wmsync-confirm" disabled /> I understand LIVE writes data</label>
+        <button type="button" style="margin-left:auto;font-weight:bold;" onclick="wmsyncSubmit('run');">&#9654; Run</button>
+      </div>
+    </form>
+  </div>
+
+  <script>
+  // Set the hidden run-mode flags, then submit. Navigation/counting force a safe dry run;
+  // only an explicit "run" honours the dry/live radio, and live additionally requires the
+  // confirmation box to be ticked.
+  function wmsyncSubmit(mode){
+    var f=document.getElementById('wmsync-form');
+    var nd=document.getElementById('wmsync-no_debug');
+    var co=document.getElementById('wmsync-count_only');
+    // Mark this submission as an explicit action so the server processes it (vs. a bare load).
+    document.getElementById('wmsync-run').value='1';
+    if(mode==='count'){ co.value='1'; nd.value=''; f.submit(); return; }
+    co.value='';
+    if(mode==='prev'||mode==='next'){ nd.value=''; f.submit(); return; }
+    // mode === 'run'
+    var live=document.querySelector('input[name=wmsync_mode]:checked').value==='live';
+    if(live){
+      if(!document.getElementById('wmsync-confirm').checked){
+        alert('To run LIVE you must tick “I understand LIVE writes data”.');
+        return;
+      }
+      nd.value='1';
+    } else {
+      nd.value='';
+    }
+    f.submit();
+  }
+  // Adjust the hidden page field then submit as a dry-run navigation.
+  function wmsyncPage(delta){
+    var p=document.getElementById('wmsync-page');
+    var v=(parseInt(p.value,10)||1)+delta;
+    if(v<1){ v=1; }
+    p.value=v;
+    wmsyncSubmit(delta<0?'prev':'next');
+  }
+  // The confirm box only matters in LIVE mode; disable+clear it otherwise.
+  function wmsyncModeChange(){
+    var live=document.querySelector('input[name=wmsync_mode]:checked').value==='live';
+    var c=document.getElementById('wmsync-confirm');
+    c.disabled=!live;
+    if(!live){ c.checked=false; }
+  }
+  </script>
+  <?php
 }
 
 function memberships_update_seat_count( $client, $wicket_membership_uuid, $seat_count) {

--- a/custom/memberships-sync.php
+++ b/custom/memberships-sync.php
@@ -18,9 +18,15 @@
 #ini_set('error_reporting', 0);
 ini_set('max_execution_time', '0');
 
-//to make sure and run the sync on the init hook
-add_action( 'init', 'wicket_action_woocommerce_loaded', 10, 1 );
+// Run on template_redirect (not init): the current user, capability checks, and the admin
+// bar are all available here, and exiting now cleanly replaces the theme output with our page.
+add_action( 'template_redirect', 'wicket_action_woocommerce_loaded', 10, 1 );
 
+/**
+ * Launches the subscription sync tool when its trigger query var is present.
+ *
+ * @return void
+ */
 function wicket_action_woocommerce_loaded() {
   if(!empty($_REQUEST['mship_subscription_sync'])) {
     wicket_sync_subscriptions();
@@ -39,9 +45,18 @@ function wicket_action_woocommerce_loaded() {
  * Runs as a dry-run by default; add `no_debug=1` to write changes. Supported request args:
  * `count_only`, `subscription_to_update`, `page_number`, `page_length`, `created_after`.
  *
- * @return void Output is echoed directly; the request is terminated with die().
+ * Renders as a standalone admin-styled page: only the WordPress admin bar and admin UI styles
+ * are loaded (not the active theme), with the current user's admin colour scheme. Admin-only.
+ *
+ * @return void Output is echoed directly; the request is terminated via wicket_sync_page_footer().
  */
 function wicket_sync_subscriptions() {
+  // Admin-only: this tool reads and (in LIVE mode) writes membership data and renders the
+  // logged-in admin bar, so require the same capability as the plugin's other admin tools.
+  if ( ! current_user_can( 'manage_options' ) ) {
+    wp_die( 'You do not have permission to access the membership subscription sync tool.' );
+  }
+
   // Sanitise the request parameters — they arrive raw from the URL/control bar.
   // A single subscription id is treated as an int; 0/invalid means "batch mode".
   $subscription_to_update = isset($_REQUEST['subscription_to_update']) ? (int) $_REQUEST['subscription_to_update'] : 0;
@@ -88,6 +103,9 @@ function wicket_sync_subscriptions() {
     }
   }
 
+  // Open the standalone admin-styled page (title + admin bar + WordPress admin colours).
+  wicket_sync_page_header();
+
   // Render the interactive control bar (plain HTML) above the streamed <pre> log.
   wicket_sync_render_control_bar([
     'subscription_to_update' => $subscription_to_update,
@@ -101,10 +119,11 @@ function wicket_sync_subscriptions() {
 
   // Bare page load: show the form to get started and run nothing else.
   if (!$action_requested) {
-    die();
+    wicket_sync_page_footer();
   }
 
-  echo "<pre>";
+  // Style the log like an admin "card" so it sits naturally on the admin-grey page.
+  echo '<pre style="background:#fff;border:1px solid #c3c4c7;border-radius:4px;padding:14px 16px;max-width:900px;margin:0;overflow:auto;">';
 
   $log = [];
 
@@ -156,7 +175,8 @@ function wicket_sync_subscriptions() {
 
     echo "Total active/on-hold subscriptions: " . count($subscription_ids) . "\n";
     echo "Subscriptions containing membership products: " . count($membership_subscriptions) . "\n";
-    die();
+    echo "</pre>";
+    wicket_sync_page_footer();
   }
   if(!empty($subscription_to_update)) {
     $subscription = wcs_get_subscription($subscription_to_update);
@@ -327,7 +347,105 @@ function wicket_sync_subscriptions() {
           #}
     } // end foreach item
   } //end foreach subscription
-  die();
+  echo "</pre>";
+  wicket_sync_page_footer();
+}
+
+/**
+ * Opens the standalone, admin-styled HTML page for the sync tool.
+ *
+ * The tool replaces the normal theme output (it exits before the template renders), so this
+ * prints a minimal document that loads ONLY the WordPress admin bar and core admin UI styles
+ * — not the active theme — and adopts the current user's admin colour scheme. Pair every call
+ * with wicket_sync_page_footer() to render the admin bar and close the document.
+ *
+ * @global \WP_Admin_Bar $wp_admin_bar  The admin bar instance, force-initialised if needed.
+ * @return void
+ */
+function wicket_sync_page_header() {
+  global $wp_admin_bar;
+
+  // Guarantee the admin bar shows even if the user's profile hides it on the front end, and
+  // initialise it directly when the normal (priority 0) template_redirect init was skipped.
+  add_filter( 'show_admin_bar', '__return_true' );
+  if ( empty( $wp_admin_bar ) && function_exists( '_wp_admin_bar_init' ) ) {
+    _wp_admin_bar_init();
+  }
+
+  // Queue only the admin-bar + core admin UI styles, plus the user's colour scheme. The
+  // theme's wp_enqueue_scripts never fires here, so no theme CSS reaches the page.
+  wp_enqueue_style( 'admin-bar' );
+  wp_enqueue_style( 'common' );
+  wp_enqueue_style( 'buttons' );
+  wp_enqueue_style( 'forms' );
+  wp_enqueue_style( 'dashicons' );
+  wicket_sync_enqueue_admin_color_scheme();
+
+  if ( ! headers_sent() ) {
+    header( 'Content-Type: text/html; charset=' . get_bloginfo( 'charset' ) );
+  }
+  ?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+<meta charset="<?php bloginfo( 'charset' ); ?>" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Wicket Membership Subscription Sync</title>
+<?php wp_print_styles(); ?>
+</head>
+<?php // admin-bar.css reserves the bar's height via html margin-top; the extra top padding adds breathing room below it. ?>
+<body class="wp-core-ui" style="background:#f0f0f1;color:#3c434a;margin:0;padding:40px 20px 20px;">
+<?php
+}
+
+/**
+ * Renders the admin bar, prints its script, closes the page, and terminates the request.
+ *
+ * @return void  Ends the request via exit.
+ */
+function wicket_sync_page_footer() {
+  if ( function_exists( 'wp_admin_bar_render' ) ) {
+    wp_admin_bar_render();
+  }
+  // Only the admin-bar script is needed (its submenu/keyboard behaviour); deps load with it.
+  wp_print_scripts( array( 'admin-bar' ) );
+  echo "\n</body>\n</html>";
+  exit;
+}
+
+/**
+ * Enqueues the current user's WordPress admin colour scheme stylesheet, when one applies.
+ *
+ * Colour schemes are normally registered only inside wp-admin; this loads and registers them
+ * so this front-end tool page can match the admin appearance. The default "fresh" scheme has
+ * no separate stylesheet (its colours are baked into the base styles), so nothing is added.
+ *
+ * @global array $_wp_admin_css_colors  Registered admin colour schemes, keyed by slug.
+ * @return void
+ */
+function wicket_sync_enqueue_admin_color_scheme() {
+  global $_wp_admin_css_colors;
+
+  // Register the schemes on the front end where wp-admin would normally have done it.
+  if ( empty( $_wp_admin_css_colors ) ) {
+    if ( ! function_exists( 'register_admin_color_schemes' ) && file_exists( ABSPATH . 'wp-admin/includes/misc.php' ) ) {
+      require_once ABSPATH . 'wp-admin/includes/misc.php';
+    }
+    if ( function_exists( 'register_admin_color_schemes' ) ) {
+      register_admin_color_schemes();
+    }
+  }
+
+  $scheme = get_user_option( 'admin_color' );
+  if ( empty( $scheme ) ) {
+    $scheme = 'fresh';
+  }
+
+  // Only non-default schemes ship a dedicated stylesheet URL; "fresh" relies on the base CSS.
+  if ( ! empty( $_wp_admin_css_colors[ $scheme ]->url ) ) {
+    wp_register_style( 'wicket-sync-admin-colors', $_wp_admin_css_colors[ $scheme ]->url, array( 'admin-bar', 'common' ), null );
+    wp_enqueue_style( 'wicket-sync-admin-colors' );
+  }
 }
 
 /**

--- a/custom/memberships-sync.php
+++ b/custom/memberships-sync.php
@@ -615,14 +615,27 @@ function wicket_sync_render_control_bar( array $state ) {
   <?php
 }
 
+/**
+ * Pushes an organization membership's seat limit (max_assignments) to the MDP.
+ *
+ * @param  object      $client                 The Wicket API client.
+ * @param  string      $wicket_membership_uuid The MDP organization membership UUID.
+ * @param  int         $seat_count             Desired seat count; values < 1 mean "unlimited".
+ *
+ * @return mixed|\WP_Error  The API response, or a WP_Error if the request throws.
+ */
 function memberships_update_seat_count( $client, $wicket_membership_uuid, $seat_count) {
+
+    // Mirror Membership_Controller: a seat count below 1 means "no limit", which the MDP
+    // represents as a null max_assignments rather than 0. Keeps both sync paths consistent.
+    $max_assignments = ( (int) $seat_count < 1 ) ? null : (int) $seat_count;
 
     // build membership payload
     $payload = [
       'data' => [
         'type' => 'organization_memberships',
         'attributes' => [
-          'max_assignments' => $seat_count
+          'max_assignments' => $max_assignments
         ],
       ]
     ];

--- a/docs/engineering/memberships_sync.md
+++ b/docs/engineering/memberships_sync.md
@@ -1,0 +1,124 @@
+---
+title: "Subscription Sync Tool — Engineering Reference"
+audience: [developer, agent]
+php_class: null
+source_files: ["custom/memberships-sync.php", "wicket.php", "includes/Membership_Tier.php", "includes/Helper.php", "includes/Membership_Controller.php"]
+---
+
+# Subscription Sync Tool — Engineering Reference
+
+A procedural (no-class) tool in `custom/memberships-sync.php` that reconciles existing WooCommerce subscriptions with imported `wicket_membership` records. It links each subscription/order/product back to its membership post and, for per-seat organization tiers, pushes the seat count to the MDP.
+
+## Loading & Entry Point
+
+The file is **conditionally included** from `wicket.php` only when the `allow_local_imports` option key exists (the **MDP Import** / `ALLOW_LOCAL_IMPORTS` feature). If MDP Import is off, none of these functions are defined.
+
+| | |
+|---|---|
+| Hook | `add_action( 'template_redirect', 'wicket_action_woocommerce_loaded', 10, 1 )` |
+| Trigger | `?mship_subscription_sync=1` query var (any front-end URL) |
+| Capability | `current_user_can( 'manage_options' )` — else `wp_die()` |
+| Output | Full standalone HTML page; request ends via `wicket_sync_page_footer()` (`exit`) |
+
+`template_redirect` is used (not `init`) so the current user, capability check, and admin bar are all available, and exiting replaces the theme output.
+
+## Function Map
+
+| Function | Responsibility |
+|---|---|
+| `wicket_action_woocommerce_loaded()` | Hook callback; calls the worker when the trigger var is present |
+| `wicket_sync_subscriptions()` | Orchestrator: sanitises input, counts, renders the page, loops subscriptions, performs the linking/seat sync |
+| `wicket_sync_page_header()` | Opens the admin-styled document (title, admin bar, admin UI styles, colour scheme) |
+| `wicket_sync_page_footer()` | Renders admin bar, prints `admin-bar` script, closes document, `exit` |
+| `wicket_sync_enqueue_admin_color_scheme()` | Registers + enqueues the current user's admin colour scheme stylesheet |
+| `wicket_sync_render_control_bar( array $state )` | Emits the GET form + client-side run-mode/pagination logic |
+| `wicket_get_mapped_product_id_for_tier( $product_id )` | Remaps a legacy product id to the tier's current product id (in-file `$product_map`, empty by default) |
+| `wicket_update_membership_json_data( $post_id, $debug, $membership_incoming )` | Rebuilds the membership JSON blob and writes it to order/subscription/user meta |
+| `memberships_update_seat_count( $client, $uuid, $seat_count )` | PATCHes MDP `organization_memberships/{uuid}` with `max_assignments` |
+| `wicket_wc_log_mship_sync( $data, $append_file_name, $level )` | WC_Logger helper (currently only called from commented-out code — see Caveats) |
+
+## Request Parameters
+
+All read from `$_REQUEST` and sanitised at the top of `wicket_sync_subscriptions()`.
+
+| Param | Type / sanitisation | Effect |
+|---|---|---|
+| `mship_subscription_sync` | presence | Triggers the tool |
+| `wmsync_run` | presence | Marks an explicit action; **absent on a bare load → form only, nothing runs** |
+| `no_debug` | presence | LIVE mode (writes). Absent → dry run (default) |
+| `count_only` | presence | Count branch only; reports totals then exits |
+| `subscription_to_update` | `(int)`, `>0` else `''` | Single-subscription scope; overrides pagination + date |
+| `page_number` | `max(1, (int))`, clamped to `total_pages` | Pagination offset |
+| `page_length` | `(int)`, must be in `[25,50,100,200]` else `100` | Per-page size |
+| `created_after` | must match `/^\d{4}-\d{2}-\d{2}$/` else `''` | `date_created >=` filter |
+
+`wmsync_mode` and `wmsync_confirm` are form-only fields; the client-side JS translates them into `no_debug` and never reach server logic directly.
+
+## Execution Flow
+
+1. Capability check → sanitise params → derive `$debug`, `$count_only`, `$action_requested`.
+2. **Pagination count** (only if `$action_requested && batch && !count_only`): IDs-only `wcs_get_subscriptions()` to compute `$pagination_total` and `$total_pages`; clamp `$page_number`.
+3. `wicket_sync_page_header()` → `wicket_sync_render_control_bar()`.
+4. **Bare load guard**: if `!$action_requested`, call `wicket_sync_page_footer()` and stop (form only).
+5. Open the `<pre>` card; print the run summary (env, mode, scope/position).
+6. **Branch:**
+   - `count_only`: query active/on-hold IDs, load each and test `has_term('membership','product_cat', …)`, print two totals, exit.
+   - `subscription_to_update`: build a single-element `$subscriptions` array.
+   - else: `wcs_get_subscriptions()` with `subscriptions_per_page = page_length`, `offset = (page-1)*page_length`, optional `date_created`.
+7. If LIVE, initialise `$wicket_api_client = wicket_api_client()`.
+8. **Per subscription → per line item** (see Matching, below).
+9. Close `<pre>`, `wicket_sync_page_footer()`.
+
+## Matching Logic (per line item)
+
+1. Resolve product id: `$item->get_variation_id()` ?: `$item->get_product_id()`.
+2. `wicket_get_mapped_product_id_for_tier()` remaps legacy → current product id.
+3. `Membership_Tier::get_tier_by_product_id( $mapped_product_id )` → tier; skip item if none, or if `get_membership_tier_post_id()` is empty.
+4. `get_posts()` on `wicket_membership` where `user_id = $sub->get_user_id()` **AND** `membership_tier_post_id = $tier_id`. The subscriber is the WooCommerce subscription user; the tier is derived from the subscribed product. If multiple match, **the first is used** (`$user_memberships[0]`).
+5. If the item meta `_membership_post_id_renew` is already set, the item is skipped (already linked).
+
+## Writes Performed (LIVE only)
+
+For a matched, not-yet-linked item:
+
+- **Membership post meta** (`update_post_meta` on `$user_memberships[0]->ID`): `membership_product_id`, `membership_subscription_id`, `membership_parent_order_id`.
+- **Subscription item meta**: `wc_add_order_item_meta( $item_id, '_membership_post_id_renew', $membership_id, true )` — the link that drives the renewal flow.
+- **JSON blob** via `wicket_update_membership_json_data()`:
+  - `add_post_meta( $order_id, '_wicket_membership_{product_id}', $json )`
+  - `add_post_meta( $subscription_id, '_wicket_membership_{product_id}', $json )`
+  - `add_user_meta( $user_id, '_wicket_membership_{post_id}', $user_json )`
+  - JSON is produced by `Helper::get_membership_json_from_membership_post_data()`, which maps the `org_seats` post meta to the `membership_seats` key in the blob. In `$debug` it buffers `var_dump()` into a collapsible toggle and writes nothing.
+
+## Per-seat Seat Sync
+
+Guard: `$Tier->is_organization_tier() && $Tier->is_per_seat() && (live client present || debug)`.
+
+- Seat count = `$item->get_quantity()` (the subscription line-item quantity).
+- LIVE: `update_post_meta( $membership_id, 'org_seats', $quantity )`, then `memberships_update_seat_count( $client, $membership_wicket_uuid, $quantity )`.
+- `memberships_update_seat_count()` normalises `(int) $seat_count < 1 → null` (unlimited), matching `Membership_Controller::update_mdp_record()`, and PATCHes `organization_memberships/{uuid}` with `attributes.max_assignments`.
+- Individual tiers and `is_per_range_of_seats()` tiers are **not** touched here.
+
+## Page Rendering
+
+`wicket_sync_page_header()` deliberately avoids `wp_head()` so the theme's `wp_enqueue_scripts` never fires — only these handles are enqueued and printed via `wp_print_styles()`: `admin-bar`, `common`, `buttons`, `forms`, `dashicons`, plus the colour scheme. The admin bar is forced on (`add_filter('show_admin_bar','__return_true')`) and `_wp_admin_bar_init()` is called directly if the global is unset. `wicket_sync_page_footer()` calls `wp_admin_bar_render()` and `wp_print_scripts(['admin-bar'])`.
+
+`wicket_sync_enqueue_admin_color_scheme()` loads `wp-admin/includes/misc.php` and calls `register_admin_color_schemes()` (normally admin-only) to populate `$_wp_admin_css_colors`, then enqueues the current user's scheme URL when one exists ("fresh" has none).
+
+## Control Bar Safety Model (client-side)
+
+`wicket_sync_render_control_bar()` emits hidden fields (`no_debug`, `count_only`, `page_number`, `wmsync_run`) set by JS:
+
+- `wmsyncSubmit('run')` — honours the dry/live radio; LIVE requires the confirm checkbox or it `alert()`s and aborts.
+- `wmsyncSubmit('count')` / `wmsyncPage(±1)` — always force `no_debug=''` (dry). Navigation/counting never write.
+- Every button sets `wmsync_run=1`; the dry/live radio always defaults to **dry** on load (LIVE is never persisted from the request).
+
+## External Dependencies
+
+`wcs_get_subscriptions()`, `wcs_get_subscription()` (WC Subscriptions); `wicket_api_client()` (base plugin); `Membership_Tier::get_tier_by_product_id()`, `Membership_Tier::is_organization_tier()/is_per_seat()/get_membership_tier_post_id()`; `Helper::get_membership_json_from_membership_post_data()`; WP `get_posts`, `*_post_meta`, `*_user_meta`, `wc_get_order_item_meta`, `wc_add_order_item_meta`, `has_term`.
+
+## Caveats
+
+- **`wicket_wc_log_mship_sync()`** is only invoked from commented-out code (the `$log` array is accumulated but not persisted). Its `source` includes `time()`, which would spawn a new WC log file per second if re-enabled — fix the source before relying on it.
+- **First-matched membership wins** when multiple memberships share a user + tier; there is no disambiguation by date or status.
+- **Admin bar is forced visible** regardless of the user's profile preference, since the page is built around it.
+- Hard-coded admin edit link uses a `/wp/wp-admin/...` path prefix in the matched-membership log line.

--- a/docs/engineering/wp-cli-tier-sync-plan.md
+++ b/docs/engineering/wp-cli-tier-sync-plan.md
@@ -145,7 +145,8 @@ this sets the pattern).
 
 ```
 wp wicket-mship tier sync   [--dry-run] [--type=<individual|organization|all>]
-                            [--config-id=<post_id>] [--yes] [--format=<table|json|csv>]
+                            [--config-id=<post_id>] [--create-products]
+                            [--backfill-products] [--yes] [--format=<table|json|csv>]
 
 wp wicket-mship tier list   [--source=<mdp|local>] [--format=<table|json|csv>]
 ```
@@ -168,6 +169,8 @@ operator can preview before syncing and diff after. Cheap to build, high diagnos
 |---|---|
 | `--dry-run` | Fetch + compute the plan, write **nothing**. Default-recommended first run. |
 | `--config-id` | Config post to attach to newly created tiers (see §6). |
+| `--create-products` | Auto-create a matching simple subscription product per created tier and link it in `product_data` (opt-in — see §13). |
+| `--backfill-products` | Also create + link a product for **existing** product-less tiers, not just newly created ones (opt-in — see §13). |
 | `--type` | Filter which MDP tiers to sync (if individual/org is distinguishable — §6). |
 | `--yes` | Skip the interactive confirmation before a live write. |
 | `--format` | Standard WP-CLI output format for list/summary. |
@@ -303,7 +306,10 @@ operator can preview before syncing and diff after. Cheap to build, high diagnos
 
 ## 10. Out of scope / future work
 
-- Linking WooCommerce products/variations to created tiers (`product_data`).
+- Linking WooCommerce products/variations to created tiers (`product_data`) — **partially
+  addressed** by the optional `--create-products` extension (§13), which creates one simple
+  subscription product per tier. Multi-product, variable-subscription, and range-bucket
+  linkage remain manual.
 - Setting renewal type, seat type, approval, and callout content.
 - Creating or reconciling `wicket_mship_config` posts.
 - Pushing WordPress → MDP (this tool is read-from-MDP only).
@@ -424,3 +430,210 @@ wp wicket-mship tier sync --config-id=1704
 # 4. Finish each tier in the admin UI: attach the WooCommerce subscription product(s)
 #    and confirm renewal settings.
 ```
+
+> With `--create-products` (§13), step 4's product attachment is done for you for the common
+> one-product-per-tier case; you only confirm/adjust pricing and renewal settings.
+
+---
+
+## 13. Extension — auto-create subscription products per tier (`--create-products`, `--backfill-products`)
+
+> **Status: implemented.** Extends the shipped `tier sync` command (§12) in
+> `includes/CLI/Tier_Sync_Command.php`. Opt-in; the default behavior (empty `product_data`)
+> is unchanged when neither flag is present.
+
+### 13.1 Goal
+
+Optionally have `tier sync` create one **WooCommerce simple subscription** product per tier,
+named after the tier, and link it into that tier's `product_data`. This removes the manual
+"attach a subscription product" admin step for the common one-product-per-tier case, so a
+synced tier is immediately valid, orderable, and safe for the "create subscriptions for all
+records" import path (§13.10).
+
+Two independent, composable flags control the scope:
+
+- **`--create-products`** — attach a product to tiers **created this run**.
+- **`--backfill-products`** — attach a product to **existing** local tiers that currently
+  have empty `product_data` (the `skip`/`update` rows), remediating tiers synced before this
+  feature existed. Runnable on its own against an already-synced site.
+
+Both share the same product-creation machinery (§13.3–13.4) and both are off by default.
+
+### 13.2 The flags
+
+| Flag | Required | Default | Applies to | Purpose |
+|---|---|---|---|---|
+| `--create-products` | No | off | rows with `action = create` | Create + link a product for each newly created tier. |
+| `--backfill-products` | No | off | `skip`/`update` rows whose `product_data` is empty | Create + link a product for existing product-less tiers. |
+
+Pass either, both, or neither. Both together = every tier ends the run with a product,
+whether it was just created or already existed empty.
+
+**Precondition (fail closed).** Either flag requires WooCommerce Subscriptions active
+(`class_exists( 'WC_Product_Subscription' )`). If a product flag is passed and WCS is
+unavailable, the command aborts before any write — same posture as the existing
+config-validity and MDP-client checks in §5.
+
+### 13.3 Product spec
+
+Each auto-created product:
+
+- **Type:** `subscription` (`WC_Product_Subscription`) — a *simple* subscription. This
+  satisfies the tier product rule (`is_type( 'subscription' )`, `Membership_Post_Types.php:591`)
+  and, crucially, renders safely in the tier admin: `Membership_Tier_CPT_Hooks::render_page()`
+  (`:114-115`) calls `wc_get_product( $id )->is_type( … )` **unguarded**, so a real product
+  avoids the fatal that a bogus/placeholder id would cause. This extension is therefore
+  *safer* than hand-inserting a fake product id.
+- **Name / title:** the tier's `name_en` (identical to `mdp_tier_name` and the tier post title).
+- **SKU (idempotency key):** deterministic, derived from the tier UUID —
+  `wicket-tier-<mdp_tier_uuid>`. Before creating, look up `wc_get_product_id_by_sku()` and
+  **reuse** the existing product if found rather than duplicating. WooCommerce enforces SKU
+  uniqueness, keeping both the create and backfill paths idempotent across re-runs — and it
+  means a backfill will re-link an orphaned product a prior create had already made for that
+  UUID rather than making a second one.
+- **Billing defaults (placeholders):** price `0`, period `year`, interval `1`, length `0`
+  (never auto-expires), no sign-up fee, no trial. These are safe placeholders the admin
+  adjusts afterward — the tool's job is *linkage*, not pricing.
+- **Status:** `publish`.
+
+### 13.4 `product_data` written
+
+A single entry linking the new product:
+
+```php
+[ 'product_id' => <new_product_id>, 'variation_id' => 0, 'max_seats' => <-1 | 1> ]
+```
+
+- `variation_id` is `0` — simple (non-variable) subscriptions have no variation. Validation
+  only demands a variation for `variable-subscription` (`Membership_Post_Types.php:616`), and
+  order→tier matching falls back to `product_id` (`Membership_Tier::get_tier_by_product_id`),
+  so a `0`/empty variation matches correctly at checkout.
+- `max_seats` per the seat-type table in §13.5.
+
+### 13.5 Seat-type handling
+
+A product is created for **every** synced tier regardless of type — including
+`per_range_of_seats`. Organization products start at **qty 1**, which the admin can adjust
+afterward for `per_seat`.
+
+| Tier | Behavior with `--create-products` |
+|---|---|
+| individual | Create one product, `product_data` `max_seats = -1` (required by validation, `:638`). |
+| organization, `per_seat` | Create one product, `max_seats = 1` (starting qty; the created membership's seat count later **tracks the purchased quantity**, so this is just a default the admin can raise). |
+| organization, `per_range_of_seats` | Create one product, `max_seats = 1` (starting qty). The created membership's `max_seats` is `-1`/`null` at runtime (open-ended range) regardless, so qty 1 is a fine starting point. Multi-bucket range products remain a manual admin refinement (§10). |
+
+> **Seat semantics (why the two org rows differ at runtime, not at creation):** `per_seat`
+> memberships take their `max_seats` from the purchased order quantity (finite); range
+> memberships get `-1`/`null`. The CLI does not encode that distinction into the product — it
+> just seeds a qty-1 product for both. See §2.1 for the `unlimited_assignments` → `seat_type`
+> mapping.
+
+### 13.6 Idempotency & safety
+
+- **Scoped by flag.** `--create-products` touches only `action = create` rows;
+  `--backfill-products` touches only `skip`/`update` rows whose `product_data` is **empty**. A
+  tier that already has products is never modified by either flag — backfill only fills a gap,
+  it never clobbers or replaces an existing linkage.
+- **Backfill is the one sanctioned exception to the name-only update policy.** Normally an
+  existing tier's `tier_data` is only name-refreshed (§6.5); `--backfill-products` additionally
+  writes `product_data` on an otherwise-empty tier. It is gated behind the explicit flag and
+  the write confirmation, and it leaves every other `tier_data` field untouched.
+- **SKU keyed on UUID** → re-running never creates a duplicate product, even after a
+  half-completed prior run; a create and a later backfill for the same UUID resolve to the
+  same product.
+- **Ordering & cleanup.**
+  - *Create path:* build (or find by SKU) the product first, then `wp_insert_post()` the tier
+    with the product already in `product_data`. If the tier insert fails, **trash the
+    just-created product** so no orphan is left; count the row as an error.
+  - *Backfill path:* the tier already exists, so build (or find by SKU) the product, then
+    `update_tier_data()` with the single-entry `product_data`. If the meta update fails, trash
+    a product this run created (leave a reused one alone); count the row as an error.
+- **`--dry-run` creates no products.** The plan gains a `product` column
+  (`create` / `backfill` / `exists` / `—`) so the operator sees exactly what would be made and
+  against which tiers. The column only appears when a product flag is set.
+
+### 13.7 Code changes
+
+- `sync()`: read `--create-products` and `--backfill-products`; when either is set, assert WCS
+  availability alongside the existing config/MDP preconditions.
+- **New** `product_for_tier( string $uuid, string $name, string $type, string $seat_type ): int|\WP_Error`
+  — resolve SKU (`wicket-tier-<uuid>`), reuse via `wc_get_product_id_by_sku()` or build a
+  `WC_Product_Subscription`, set name/SKU/billing meta, save, return the id. Shared by both
+  paths (create passes MDP-derived values; backfill passes the existing tier's `tier_data`).
+- **New** `single_product_data( int $product_id, string $type, string $seat_type ): array`
+  — builds the one-entry `product_data` (`max_seats` per the §13.5 table). Used by both paths.
+- `create_tier()` / `build_tier_data()`: when `--create-products` is on, seed `product_data`
+  from `single_product_data()` instead of `[]`.
+- **New** `backfill_tier_product( int $post_id )` — for a `skip`/`update` row whose tier has
+  empty `product_data`: create/find the product, then `update_tier_data()` with the new
+  `product_data`; trash a freshly-created product on failure.
+- The plan builder: for `skip`/`update` rows, also detect "empty `product_data`" so the
+  `product` column can show `backfill "<name>"`; fold the backfill count into the confirm
+  prompt and final summary.
+- `print_results()` / the plan rows: add a `product` column for dry-run visibility.
+
+### 13.8 Decisions / open questions
+
+- **Backfill existing product-less tiers.** ✅ **Adopted** as `--backfill-products` (§13.2).
+  It is the sanctioned exception to the name-only update policy (§13.6) and the remediation
+  path for tiers synced empty before this feature — directly the failure surfaced in §13.10.
+  Kept as a *separate* opt-in flag (not folded into `--create-products`) so an operator can
+  remediate an existing site without also re-running a create pass.
+- **Configurable billing?** v1 hardcodes yearly / price `0` placeholders. `--product-price`
+  / `--product-period` could follow; not required for linkage.
+- **`per_range_of_seats`** gets a single qty-1 product like every other tier; multi-bucket
+  range refinement stays manual (§10).
+
+### 13.9 Usage
+
+```console
+# Create missing tiers AND a matching product for each (preview, then apply).
+wp wicket-mship tier sync --config-id=1704 --create-products --dry-run
+wp wicket-mship tier sync --config-id=1704 --create-products
+
+# Remediate an already-synced site: add products to existing product-less tiers only.
+wp wicket-mship tier sync --config-id=1704 --backfill-products --dry-run
+wp wicket-mship tier sync --config-id=1704 --backfill-products
+
+# Belt and braces: new tiers get products AND existing empty ones are backfilled.
+wp wicket-mship tier sync --config-id=1704 --create-products --backfill-products
+```
+
+Dry-run plan with the extra `product` column (both flags on):
+
+```console
+action   type          name              uuid                                   post_id  product
+create   individual    Student Member    3fd27d2f-e47d-4a1d-9839-31097f9d8c7d            create
+create   organization  Vet Clinic 6+     4caf0d73-48e6-47e2-86a0-b642ea975e1d            create
+skip     individual    Full Member       6edcfa3a-d859-4f41-a19d-9cfe77ea85ff   1679     backfill
+skip     individual    WooSimplePlan 1   22f3984d-c6be-482b-8397-08ad1fb754e0   1230     exists
+```
+
+- `create` — a new tier and its product would both be made.
+- `backfill` — an existing tier has empty `product_data`; a product would be made and linked.
+- `exists` — the existing tier already has products; left untouched.
+- `—` — no product action for this row (flag not set for this action, or `--type` filtered it).
+
+### 13.10 Interaction with the membership import ("create subscriptions for all records")
+
+This extension directly fixes a latent failure in the import path. When
+`wicket_mship_import_create_subscriptions` is enabled, every active imported membership calls
+`Import_Controller::createSubscriptionForRenewal()` (`includes/Import_Controller.php:129`,
+`:243`, `:308`), which does:
+
+```php
+$products   = $Membership_Tier->get_products_data();
+$product_id = !empty( $products[0]['variation_id'] ) ? $products[0]['variation_id'] : $products[0]['product_id'];
+$wc_product = wc_get_product( $product_id );   // false when product_data is empty
+$subscription->add_product( $wc_product );      // fatal on false (:338)
+```
+
+- **Product-less tier (today):** `$products[0]` is undefined → `$product_id` is `null` →
+  `wc_get_product( null )` returns `false` → `add_product( false )` **fatals** the record.
+- **After `--create-products` / `--backfill-products`:** `product_data[0]` resolves to a real
+  simple subscription product (`variation_id` is `0`, so it falls through to `product_id`),
+  `wc_get_product()` returns a valid product, and the import succeeds. Price `0` is correct —
+  the method creates no order and takes no payment.
+
+**Operator sequencing:** run the product-creating sync **before** the import. For a site whose
+tiers were already synced empty, `--backfill-products` is the remediation to run first.

--- a/docs/engineering/wp-cli-tier-sync-plan.md
+++ b/docs/engineering/wp-cli-tier-sync-plan.md
@@ -1,0 +1,426 @@
+---
+title: "WP-CLI Tier Sync Tool — Implementation Plan"
+audience: [developer, agent]
+status: proposal
+php_class: null
+source_files:
+  - "includes/Membership_Tier.php"
+  - "includes/Membership_Post_Types.php"
+  - "includes/Membership_Config.php"
+  - "includes/Helper.php"
+  - "../wicket-wp-base-plugin/includes/helpers/helper-unsorted.php (get_individual_memberships)"
+  - "../wicket-wp-base-plugin/includes/helpers/helper-init.php (wicket_api_client)"
+---
+
+# WP-CLI Tier Sync Tool — Implementation Plan
+
+## 1. Goal
+
+Provide a **WP-CLI command** that connects to the external Wicket **MDP** (Membership
+Data Platform) through the API exposed by `wicket-wp-base-plugin`, reads the membership
+tiers defined on the external site, and **creates matching `wicket_mship_tier` posts in
+WordPress** — each one linked to its MDP tier via `mdp_tier_uuid`.
+
+This automates what is today a manual process: an admin opening **Add New Tier**,
+selecting the MDP tier from a dropdown, and saving. For a site with dozens of MDP tiers,
+that is slow and error-prone. The CLI tool will fetch the authoritative list from the MDP
+and reconcile local tier posts against it.
+
+**Non-goals (this phase):** creating/editing configs, linking WooCommerce products,
+setting renewal logic, or pushing data *up* to the MDP. Those remain manual or belong to a
+later phase. See [§10 Out of Scope](#10-out-of-scope--future-work).
+
+---
+
+## 2. Background — how tiers link to the MDP today
+
+Confirmed by reading the code (not assumed):
+
+- **MDP tier fetch.** `get_individual_memberships( $id = '', $params = [] )` in
+  `wicket-wp-base-plugin/includes/helpers/helper-unsorted.php` calls
+  `wicket_api_client()->get('memberships', ['query' => $params])`. It returns a JSON:API
+  payload — `['data' => [ { 'id' => <uuid>, 'attributes' => { 'name_en' => ..., 'category_weight' => ... } }, ... ]]`.
+  This is the same call `Admin_Controller` (line ~416) and `Membership_Tier_CPT_Hooks` (line ~322)
+  already use to populate the MDP-tier dropdown, so it is the authoritative source list.
+- **API client.** `wicket_api_client()` (base plugin `helper-init.php`) builds a
+  `\Wicket\Client` from `get_wicket_settings()` (JWT, endpoint, person_id) and returns
+  `false` if the SDK or connection is unavailable. All MDP access flows through this.
+- **Local tier storage.** Tiers are the `wicket_mship_tier` CPT
+  (`Helper::get_membership_tier_cpt_slug()`). Their MDP linkage and behavior live in a
+  serialized `tier_data` post-meta array. Key fields (from `Membership_Post_Types::register_membership_tier_cpt_fields()`
+  and `docs/engineering/membership_tier_data_structure.md`):
+  - `mdp_tier_uuid` (**required**, authoritative link — validated non-empty on REST save)
+  - `mdp_tier_name` (**required**, validated non-empty)
+  - `config_id` (**required** — every tier must reference a `wicket_mship_config` post)
+  - `type` (`individual` | `organization`)
+  - `renewal_type`, `seat_type`, `product_data[]`, `approval_required`, etc.
+- **Idempotency hook.** `Membership_Tier::get_tier_id_by_wicket_uuid( $uuid )` iterates all
+  tier posts and returns the post ID whose `tier_data['mdp_tier_uuid']` matches — this is
+  how we detect "tier already exists" and avoid duplicates.
+
+**Constraint that shapes the design:** a tier cannot be validly saved without a
+`config_id`. The MDP does not supply a config (configs are a WordPress-side concept:
+renewal windows, grace periods, billing cycle). **Decision:** the operator supplies the
+config via a required `--config-id` flag; the CLI attaches it to every created tier
+(option (a) below).
+
+### 2.1 Confirmed MDP response shape (verified against staging)
+
+Verified live on `2026-07-03` against `https://memberships-test-api.staging.wicketcloud.com`
+via `wp eval` in the `php` container (`get_individual_memberships('', ['page' => ['size' => 100]])`).
+Sample item and findings:
+
+```jsonc
+{
+  "id": "6edcfa3a-d859-4f41-a19d-9cfe77ea85ff",   // → mdp_tier_uuid
+  "type": "memberships",
+  "attributes": {
+    "name_en": "Full Member", "name_fr": "...", "name_es": "...",  // → mdp_tier_name (use name_en)
+    "type": "individual",              // "individual" | "organization"  → tier_data['type']
+    "approval": "approval_not_required", // "approval_not_required" | (assumed) "approval_required"
+    "slug": "full-member", "code": "FULL", "active": true,
+    "max_assignments": 1, "unlimited_assignments": false,  // org seat hints (see below)
+    "default_grace_period_days": 0
+  },
+  "relationships": { "organization": { "data": null }, "parent": { "data": null }, ... }
+}
+```
+
+Key confirmed facts (these resolve the former open questions):
+
+- **Individual vs organization — distinguishable in ONE endpoint.** `attributes.type` is
+  `"individual"` or `"organization"`. **Note the helper name is misleading:**
+  `get_individual_memberships()` returns *both* types (staging: 21 individual + 9
+  organization = 30). So `--type` filtering is real and must be done on `attributes.type`
+  (client-side is fine at this scale; a server-side `filter[type]` is a possible
+  optimization but unverified).
+- **Pagination — JSON:API, opt-in.** A bare call returns `links => []` (empty). Passing
+  `['page' => ['size' => N]]` returns a full `links` object (`self/first/last/prev/next`).
+  With `page[size]=100`, staging returned all 30 with `next: null`, confirming 30 is the
+  true total. **The CLI must paginate defensively:** pass an explicit `page[size]` and
+  follow `links.next` until it is `null` — do not trust a single bare response to be
+  complete.
+- **Localization.** `name_en`, `name_fr`, `name_es` (plus base `name`) are all present.
+  Use **`name_en`** for `mdp_tier_name` to match the existing admin dropdown.
+
+**Bonus fields available to seed `tier_data` defaults** (nice-to-have, not required for v1):
+`attributes.approval` → `approval_required` (staging is uniformly `approval_not_required`;
+the `approval_required` value is assumed, not yet observed). `relationships.organization`
+was `null` for all sampled org tiers, so it cannot be relied on to identify org tiers —
+use `attributes.type`.
+
+#### Organization seat type mapping
+
+For `type: "organization"` tiers, the MDP `unlimited_assignments` flag maps to the
+plugin's `tier_data['seat_type']`:
+
+| MDP `unlimited_assignments` | → plugin `seat_type` | Plugin meaning |
+|---|---|---|
+| `false` | `per_seat` | Seat count is **limited to the purchased product quantity**. Exactly one product; `product_data[0].max_seats = -1` (a sentinel meaning "no fixed cap in `product_data`" — the real cap is the qty bought, pushed to MDP `max_assignments` by the sync tool). |
+| `true`  | `per_range_of_seats` | The **range** setting: multiple products, each a bounded seat-range bucket. |
+
+Observed org samples: `{max_assignments:5, unlimited:false}` ("Vet Clinic for 2-5") →
+`per_seat`; `{max_assignments:null, unlimited:true}` ("Vet Clinic for 6+") →
+`per_range_of_seats`.
+
+**Why this is consistent (do not "fix" it):** `max_seats = -1` is *not* "unlimited seats" —
+it is a sentinel meaning the cap is not hardcoded in `product_data`. For `per_seat` the
+effective seat count is the purchased quantity (`memberships-sync.php:328-334` reads
+`$item->get_quantity()` and writes it to MDP `max_assignments`), i.e. a **finite, limited**
+count. `per_range_of_seats` is the open-ended / range configuration. So MDP
+`unlimited_assignments:true → per_range_of_seats` and `false → per_seat` matches the
+plugin's semantics exactly.
+
+> Scope note: the CLI sets `seat_type` from this rule. The matching `product_data[]`
+> (single `max_seats:-1` product for `per_seat`; range buckets for `per_range_of_seats`)
+> and WooCommerce product linkage remain a later phase (§10) — done by the admin in the UI.
+> See §6.9 for how product-less tiers are created safely.
+
+---
+
+## 3. Command design
+
+Establish a new namespaced WP-CLI command (no WP-CLI commands exist in this stack yet, so
+this sets the pattern).
+
+```
+wp wicket-mship tier sync   [--dry-run] [--type=<individual|organization|all>]
+                            [--config-id=<post_id>] [--yes] [--format=<table|json|csv>]
+
+wp wicket-mship tier list   [--source=<mdp|local>] [--format=<table|json|csv>]
+```
+
+### `tier sync` (the core tool)
+For each MDP tier returned by the API:
+1. Look up an existing local tier by `mdp_tier_uuid`.
+2. If none exists → **create** a `wicket_mship_tier` post, populate `tier_data`
+   (`mdp_tier_uuid`, `mdp_tier_name`, `config_id`, `type`, sensible defaults).
+3. If one exists → **skip** by default; optionally refresh `mdp_tier_name` if it drifted
+   (report as "updated").
+4. Emit a per-tier result line and a final summary (`created`, `skipped`, `updated`, `errors`).
+
+### `tier list` (read-only helper / verification)
+Prints the MDP tier list (`--source=mdp`) or local tier posts (`--source=local`) so an
+operator can preview before syncing and diff after. Cheap to build, high diagnostic value.
+
+### Flags
+| Flag | Purpose |
+|---|---|
+| `--dry-run` | Fetch + compute the plan, write **nothing**. Default-recommended first run. |
+| `--config-id` | Config post to attach to newly created tiers (see §6). |
+| `--type` | Filter which MDP tiers to sync (if individual/org is distinguishable — §6). |
+| `--yes` | Skip the interactive confirmation before a live write. |
+| `--format` | Standard WP-CLI output format for list/summary. |
+
+**Safety defaults:** live writes require either `--yes` or an interactive
+`WP_CLI::confirm()`. Mirrors the dry-run-first ethos of the existing subscription sync tool.
+
+---
+
+## 4. Where the code lives
+
+- **New file:** `includes/CLI/Tier_Sync_Command.php`, class
+  `Wicket_Memberships\CLI\Tier_Sync_Command` (PHP 8.1+, namespaced, `snake_case` methods —
+  matches the plugin's conventions in CLAUDE.md).
+- **Registration:** in `wicket.php`, guarded by `if ( defined('WP_CLI') && WP_CLI )`, call
+  `WP_CLI::add_command( 'wicket-mship tier', ... )`. Load the class file there (or via the
+  existing autoload path). This keeps CLI wiring out of the web request path entirely.
+- **Reuse, don't reinvent:** use `get_individual_memberships()` for the fetch,
+  `Membership_Tier::get_tier_id_by_wicket_uuid()` for idempotency,
+  `Helper::get_membership_tier_cpt_slug()` for the CPT slug, and the same `tier_data` shape
+  the REST controller writes. Do **not** duplicate the MDP HTTP logic.
+
+---
+
+## 5. Execution flow (`tier sync`)
+
+1. **Preconditions.** Confirm `wicket_api_client()` returns a live client; abort with
+   `WP_CLI::error()` if the MDP is unreachable (don't create half-linked tiers).
+2. **Fetch.** Call `get_individual_memberships('', ['sort' => '-category_weight'])`.
+   Handle empty/`null` responses gracefully (the helper swallows exceptions and can return
+   `null`). Consider pagination — verify whether the MDP `memberships` endpoint paginates
+   and, if so, loop over pages (see §6).
+3. **Resolve config.** Determine the `config_id` to attach (from `--config-id`, or a
+   documented default/lookup — §6). Validate the post exists and is a `wicket_mship_config`.
+4. **Plan.** Build a reconciliation list: for each MDP tier, mark `create` / `skip` /
+   `update`. In `--dry-run`, print the plan + summary and exit here.
+5. **Confirm.** If not `--dry-run` and not `--yes`, `WP_CLI::confirm()` the write count.
+6. **Apply.** For each `create`: `wp_insert_post()` a `wicket_mship_tier` (status
+   `publish`), then persist the serialized `tier_data` meta. Set `mdp_tier_name` from
+   `attributes.name_en`, `type` per §6, and defaults for the remaining fields.
+7. **Report.** Per-tier line (`WP_CLI::log`) + a `WP_CLI\Utils\format_items()` summary
+   table and final `WP_CLI::success()`.
+
+---
+
+## 6. Decisions (resolved) & remaining questions
+
+### Resolved
+1. **Config linkage.** ✅ **Decided:** operator supplies `--config-id` (required); the CLI
+   attaches that single config to every created tier. The command validates the post
+   exists and is a `wicket_mship_config` before writing.
+2. **Individual vs organization.** ✅ **Confirmed distinguishable** via `attributes.type`
+   in the one `memberships` endpoint (see §2.1). `--type` filters client-side on that
+   field; `tier_data['type']` is set from it.
+3. **Pagination.** ✅ **Confirmed JSON:API pagination** (opt-in via `page[size]`, follow
+   `links.next`). The fetch loops until `links.next` is `null`.
+4. **Localization.** ✅ Use `name_en` for `mdp_tier_name` (matches the admin dropdown);
+   `name_fr` / `name_es` also available if multi-locale naming is wanted later.
+
+### Resolved (cont.)
+9. **Products — create tiers with empty `product_data`; no placeholder.** ✅ Product
+   selection happens later in the admin UI. Verified:
+   - The CLI writes `tier_data` directly (`wp_insert_post()` + `update_post_meta()`), which
+     **bypasses the REST `product_data` validation** — so the "≥1 product required" rule
+     does not apply to the CLI path. Empty `product_data` writes fine.
+   - Empty `product_data` is safe downstream: `Membership_Tier::get_all_tier_product_ids()`
+     guards with `if ( $products_data )` (`Membership_Tier.php:50`) and skips product-less
+     tiers, so they never reach product lookups.
+   - A **placeholder must NOT be used.** `Membership_Tier_CPT_Hooks::render_page()`
+     (`:114-115`) calls `wc_get_product( $id )->is_type( … )` with no null guard while
+     rendering the tier admin; a non-existent `product_id` returns `false` and fatals the
+     **entire** tier admin screen (`Error: is_type() on bool`). Even a real non-subscription
+     product would fail REST validation (`Membership_Post_Types.php:590`) when the admin
+     later saves. So a placeholder would have to be a genuine subscription product — exactly
+     the manual step we are deferring. Empty is correct.
+   - ⚠️ **Quick manual verify:** confirm the React tier-edit app loads an existing tier with
+     empty `product_data` without JS error. Low risk — the "Add New Tier" flow already
+     starts from empty products, so the editor handles the empty case by design.
+
+### Still to confirm during implementation
+5. **Update policy.** On an existing tier, only refresh `mdp_tier_name`, or leave the local
+   post fully untouched? Proposal: refresh name only, never touch config/products.
+   - yes
+6. **`approval_required` mapping.** Staging shows only `approval_not_required`. Confirm the
+   opposite enum value (assumed `approval_required`) against a tenant that uses it before
+   auto-seeding `tier_data['approval_required']`. Safe fallback: default to `false`.
+   - yes always false
+7. **Server-side type filter.** Client-side filtering on `attributes.type` is fine at
+   current scale (30 tiers). A `filter[type]` query param could reduce payload but is
+   unverified — optional optimization, not required.
+   - no
+8. **Naming / menu.** Confirm the command namespace (`wicket-mship tier`) fits any future
+   `wp wicket-mship ...` command family.
+
+---
+
+## 7. Idempotency & safety
+
+- **Keyed on `mdp_tier_uuid`** via `get_tier_id_by_wicket_uuid()` — re-running `sync` never
+  creates duplicates.
+- **`--dry-run` is the recommended first run** and writes nothing.
+- **Live writes gated** behind `--yes` / `WP_CLI::confirm()`.
+- **Fail closed on API errors** — if the MDP is down or returns empty, abort rather than
+  create tiers with missing linkage.
+- **No deletes.** The tool only creates (and optionally name-updates). MDP tiers that have
+  no local match are *reported*, never auto-created-then-removed; local tiers absent from
+  the MDP are left alone (flagged in output for operator review).
+
+---
+
+## 8. Testing plan
+
+- **Unit (PHPUnit + Brain Monkey):** mock `get_individual_memberships()` to return a fixed
+  JSON:API fixture; assert the reconciliation plan (create vs skip) and the exact
+  `tier_data` written. Use existing `tests/factories/` for tier/config posts.
+- **Idempotency:** run `sync` twice against the same fixture → second run creates 0.
+- **Dry-run:** assert zero posts written and a correct plan printed.
+- **Error path:** `wicket_api_client()` returns `false` → command errors, writes nothing.
+- **Manual QA:** on a dev site with MDP creds, `tier list --source=mdp`, then
+  `tier sync --dry-run`, then a live `sync`, then verify tiers appear in the admin list
+  with correct UUID linkage.
+
+---
+
+## 9. Rollout
+
+1. Land command + `tier list` + `--dry-run` first (read-only surface, low risk).
+2. QA dry-run output against a real MDP tenant.
+3. Enable live `sync` behind confirmation.
+4. Document usage in `docs/guides/` (operator-facing) alongside `membership-sync.md`.
+
+---
+
+## 10. Out of scope / future work
+
+- Linking WooCommerce products/variations to created tiers (`product_data`).
+- Setting renewal type, seat type, approval, and callout content.
+- Creating or reconciling `wicket_mship_config` posts.
+- Pushing WordPress → MDP (this tool is read-from-MDP only).
+- Deleting/archiving local tiers whose MDP tier was removed.
+
+---
+
+## 11. Effort estimate (rough)
+
+| Piece | Est. |
+|---|---|
+| Command scaffold + registration + `tier list` | 0.5 day |
+| `tier sync` fetch/reconcile/create + dry-run + summary | 1 day |
+| Config-linkage decision + edge cases (pagination, type) | 0.5 day |
+| PHPUnit tests | 0.5 day |
+| Operator docs + QA | 0.5 day |
+| **Total** | **~3 days** (pending §6 answers) |
+
+---
+
+## 12. Usage reference (as built)
+
+> **Status: implemented.** Command class: `Wicket_Memberships\CLI\Tier_Sync_Command`
+> (`includes/CLI/Tier_Sync_Command.php`), registered in `wicket.php` under a
+> `defined( 'WP_CLI' ) && WP_CLI` guard. Verified end-to-end against the staging MDP
+> (`memberships-test-api.staging.wicketcloud.com`).
+
+### Prerequisites
+
+- The `wicket-wp-memberships` plugin is active and WP-CLI is available in the environment.
+- Wicket MDP settings are configured (JWT + endpoint); the command aborts if the API
+  client is unavailable.
+- A valid `wicket_mship_config` post exists on **this** site — its ID is passed to
+  `--config-id`. Config IDs are environment-specific (they differ per site).
+
+### Commands
+
+```
+wp wicket-mship tier sync --config-id=<post_id> [--type=<type>] [--dry-run] [--yes] [--format=<format>]
+wp wicket-mship tier list [--source=<source>] [--format=<format>]
+```
+
+#### `tier sync` — create local tiers from the MDP
+
+Fetches every MDP tier (paginated), matches each against local tiers by `mdp_tier_uuid`,
+and creates the missing ones. Created tiers are attached to `--config-id`, linked by UUID,
+and left with **no products** (added later in the admin UI). Existing tiers are skipped;
+only a drifted `mdp_tier_name` is refreshed.
+
+| Arg | Required | Default | Values | Purpose |
+|---|---|---|---|---|
+| `--config-id=<post_id>` | **Yes** | — | any valid `wicket_mship_config` post ID | Config attached to every created tier. Validated (`get_post()` + post type) before any MDP call. |
+| `--type=<type>` | No | `all` | `all` \| `individual` \| `organization` | Only sync MDP tiers of this type (filtered on `attributes.type`). |
+| `--dry-run` | No | off | flag | Compute and print the plan; write nothing. Recommended first run. |
+| `--yes` | No | off | flag | Skip the interactive confirmation before writing. |
+| `--format=<format>` | No | `table` | `table` \| `json` \| `csv` | Output format for the plan/results table. |
+
+Behavior notes:
+- **Fails fast** with a clear error if `--config-id` is missing/invalid, or if the MDP
+  client is unavailable — before writing anything.
+- **Idempotent** — re-running creates nothing already linked by `mdp_tier_uuid`.
+- Live writes require `--yes` or an interactive `y/n` confirmation.
+- Per created tier, `tier_data` is written as: `mdp_tier_uuid`, `mdp_tier_name` (`name_en`),
+  `config_id`, `type`, `renewal_type: subscription` (benign default), `approval_required`
+  (from MDP `approval`), `product_data: []`, and — for organization tiers — `seat_type`
+  (`unlimited_assignments ? per_range_of_seats : per_seat`). `membership_tier_slug` is set
+  from the MDP `slug` by the existing `save_post_wicket_mship_tier` hook.
+
+#### `tier list` — read-only preview / diff
+
+| Arg | Required | Default | Values | Purpose |
+|---|---|---|---|---|
+| `--source=<source>` | No | `mdp` | `mdp` \| `local` | Read tiers from the MDP, or from local tier posts. |
+| `--format=<format>` | No | `table` | `table` \| `json` \| `csv` \| `count` \| `ids` | Output format. |
+
+### What a dry run looks like
+
+```console
+$ wp wicket-mship tier sync --config-id=1704 --dry-run
+Fetching membership tiers from the MDP...
+action   type          name                                     uuid                                   post_id
+skip     individual    Full Member                              6edcfa3a-d859-4f41-a19d-9cfe77ea85ff   1679
+skip     individual    WooSimplePlan 1                          22f3984d-c6be-482b-8397-08ad1fb754e0   1230
+create   individual    Student Member                           3fd27d2f-e47d-4a1d-9839-31097f9d8c7d
+create   organization  Veterinary Clinic Membership for 2 - 5   53580191-ffad-477e-83ee-aceea9265a3b
+create   organization  Veterinary Clinic Membership for 6+      4caf0d73-48e6-47e2-86a0-b642ea975e1d
+...
+Plan: 14 to create, 0 to update (name), 16 unchanged.
+Success: Dry run complete — no changes written.
+```
+
+- `skip` — a local tier already links this UUID (its post ID is shown); nothing changes.
+- `create` — no local tier links this UUID; it would be created (blank `post_id`).
+- `update` — the local tier exists but its `mdp_tier_name` drifted; the name would be
+  refreshed (not shown above; count reported in the `Plan:` line).
+
+Dropping `--dry-run` prints the same plan, then prompts:
+
+```console
+Create 14 and update 0 local tier(s)? [y/n] y
+Created tier #5168 "Student Member" (3fd27d2f-d859-...).
+...
+Success: Done. Created 14, updated 0, errors 0.
+```
+
+### Typical workflow
+
+```console
+# 1. See what the MDP has.
+wp wicket-mship tier list --source=mdp
+
+# 2. Preview the sync against the target config (writes nothing).
+wp wicket-mship tier sync --config-id=1704 --dry-run
+
+# 3. Apply it.
+wp wicket-mship tier sync --config-id=1704
+
+# 4. Finish each tier in the admin UI: attach the WooCommerce subscription product(s)
+#    and confirm renewal settings.
+```

--- a/docs/guides/membership-sync.md
+++ b/docs/guides/membership-sync.md
@@ -1,0 +1,38 @@
+---
+title: "Subscription Sync Tool"
+audience: [implementer, support]
+---
+
+# Subscription Sync Tool
+
+The Subscription Sync tool links existing WooCommerce subscriptions to their membership records. It is meant for use **after a membership import** where subscriptions were *not* created during the import, but matching subscriptions already exist and need to be connected so renewals work correctly.
+
+For each active or on-hold subscription, the tool finds the membership belonging to the same user (matched by email) on the same tier (resolved from the product on the subscription), and links the subscription, order, and product information back to that membership record.
+
+## Opening the Tool
+
+The tool is only available while **MDP Import** is enabled in the Wicket Memberships settings. When it is enabled, a link to open the tool appears in the import instructions on the settings page. The tool opens on its own page showing only the WordPress admin bar.
+
+Opening the page does **not** run anything — it shows the controls so you can choose what to do first.
+
+## The Controls
+
+- **Mode — Dry run / LIVE.** Dry run is always selected when the page loads. A dry run shows exactly what *would* happen without changing anything. To make real changes you must select **LIVE** and tick the **"I understand LIVE writes data"** box; only then will the Run button apply changes.
+- **Run.** Performs the sync for the current page using the selected mode.
+- **Count Only.** Reports how many subscriptions exist and how many contain membership products. It makes no changes and is a safe way to gauge the size of the job.
+- **Created after.** Optional date filter. Leave it empty to include everything; once set, it stays applied as you move between pages. Use the clear icon to remove it.
+- **Per page.** How many subscriptions to process per page.
+- **Prev / Next.** Move between pages. The bar shows your current page and position within the total. Moving between pages always runs as a safe dry run — it never writes.
+- **Single subscription ID.** Process just one subscription by its ID. This overrides the pagination and date filter.
+
+## Special Functionality
+
+### Per-seat organization tiers — seat count sync
+
+When a subscription being synced belongs to an **organization** tier configured as **per seat**, the tool uses the **subscription's product quantity** as the membership's seat count. That quantity is saved on the membership and written back to the MDP as the maximum number of people who can be assigned to the membership.
+
+Notes:
+
+- This applies **only** to per-seat organization tiers. Individual tiers and range-based organization tiers are not affected by this behavior.
+- A quantity below 1 is treated as **unlimited**.
+- The seat count is only written to the MDP on a **LIVE** run. A dry run just reports what the seat count would be.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,9 @@ audience: [implementer, support, developer, end-user]
 - [Membership_Config Data Structure](engineering/membership_config_data_structure.md) — Renewal windows, late fees, calendar/anniversary cycles
 - [Membership_Tier Data Structure](engineering/membership_tier_data_structure.md) — Tier-to-product linkage, renewal types, approval flows
 
+### Tools
+- [Subscription Sync Tool — Engineering Reference](engineering/memberships_sync.md) — How `custom/memberships-sync.php` links subscriptions to memberships and syncs per-seat MDP seat counts
+
 ### Class Reference
 - [Admin_Controller](engineering/Class-Admin_Controller.md) — Admin menu pages, status transition validation, React app mounting
 - [Helper](engineering/Class-Helper.md) — Static utilities: CPT slugs, status names, allowed transitions, logging
@@ -32,3 +35,4 @@ audience: [implementer, support, developer, end-user]
 
 ## Guides (End Users)
 - [Link a Membership Tier to a WooCommerce Product](guides/link-tier-to-product.md) — Connect tiers to subscription products so memberships are created on purchase
+- [Subscription Sync Tool](guides/membership-sync.md) — Link existing subscriptions to imported membership records; per-seat org seat sync

--- a/includes/CLI/Tier_Sync_Command.php
+++ b/includes/CLI/Tier_Sync_Command.php
@@ -58,6 +58,15 @@ class Tier_Sync_Command {
    * the MDP does not supply a config, and a tier is invalid without one. Environment
    * specific — the same config has different IDs across sites.
    *
+   * [--create-products]
+   * : For each tier created this run, also create a simple WooCommerce subscription product
+   * named after the tier and link it into the tier's product_data. Requires WooCommerce
+   * Subscriptions. See docs/engineering/wp-cli-tier-sync-plan.md §13.
+   *
+   * [--backfill-products]
+   * : Also create + link a product for existing local tiers that currently have no products,
+   * not just newly created ones. Requires WooCommerce Subscriptions.
+   *
    * [--type=<type>]
    * : Only sync tiers of this MDP type.
    * ---
@@ -95,20 +104,34 @@ class Tier_Sync_Command {
    *     # Sync only organization tiers, no prompt.
    *     $ wp wicket-mship tier sync --config-id=123 --type=organization --yes
    *
+   *     # Create tiers and a matching subscription product for each.
+   *     $ wp wicket-mship tier sync --config-id=123 --create-products
+   *
+   *     # Backfill products onto existing product-less tiers.
+   *     $ wp wicket-mship tier sync --config-id=123 --backfill-products
+   *
    * @param array<int, string>    $args        Positional args (unused).
    * @param array<string, string> $assoc_args  Associative args from the flags above.
    *
    * @return void
    */
   public function sync( $args, $assoc_args ) {
-    $dry_run   = Utils\get_flag_value( $assoc_args, 'dry-run', false );
-    $type      = Utils\get_flag_value( $assoc_args, 'type', 'all' );
-    $format    = Utils\get_flag_value( $assoc_args, 'format', 'table' );
-    $config_id = (int) Utils\get_flag_value( $assoc_args, 'config-id', 0 );
+    $dry_run           = Utils\get_flag_value( $assoc_args, 'dry-run', false );
+    $type              = Utils\get_flag_value( $assoc_args, 'type', 'all' );
+    $format            = Utils\get_flag_value( $assoc_args, 'format', 'table' );
+    $config_id         = (int) Utils\get_flag_value( $assoc_args, 'config-id', 0 );
+    $create_products   = (bool) Utils\get_flag_value( $assoc_args, 'create-products', false );
+    $backfill_products = (bool) Utils\get_flag_value( $assoc_args, 'backfill-products', false );
 
     // Fail before any MDP work if the config target is invalid — a tier cannot be saved
     // without a valid config, so there is no point fetching tiers we could not create.
     $this->assert_valid_config( $config_id );
+
+    // Either product flag mints WC_Product_Subscription objects, so fail closed up front if
+    // WooCommerce Subscriptions is unavailable — same posture as the config/MDP checks.
+    if ( $create_products || $backfill_products ) {
+      $this->assert_subscriptions_available();
+    }
 
     // Confirm the MDP is reachable up front; creating tiers with a dead client would
     // produce half-linked posts.
@@ -144,12 +167,26 @@ class Tier_Sync_Command {
 
       $existing_id = Membership_Tier::get_tier_id_by_wicket_uuid( $uuid );
 
+      // Product column: '—' none, 'create' new tier gets one, 'backfill' fills an empty
+      // existing tier, 'exists' existing tier already has products (left alone).
+      $product_action = '—';
+
       if ( false === $existing_id ) {
         $action = 'create';
+
+        if ( $create_products ) {
+          $product_action = 'create';
+        }
       } else {
+        // Load the existing tier once for both the name-drift check and the product check.
+        $existing_tier = new Membership_Tier( $existing_id );
         // Existing tier: only a name drift is actionable (update policy = name only).
-        $existing_name = ( new Membership_Tier( $existing_id ) )->get_mdp_tier_name();
-        $action        = ( $existing_name !== $name ) ? 'update' : 'skip';
+        $action        = ( $existing_tier->get_mdp_tier_name() !== $name ) ? 'update' : 'skip';
+
+        // Only surface a product decision for existing tiers when backfill was requested.
+        if ( $backfill_products ) {
+          $product_action = empty( $existing_tier->get_products_data() ) ? 'backfill' : 'exists';
+        }
       }
 
       $plan[] = array(
@@ -158,15 +195,18 @@ class Tier_Sync_Command {
         'name'    => $name,
         'uuid'    => $uuid,
         'post_id' => $existing_id ?: '',
+        'product' => $product_action,
         'mdp'     => $mdp_tier,
       );
     }
 
-    $to_create = array_filter( $plan, static fn( $row ) => 'create' === $row['action'] );
-    $to_update = array_filter( $plan, static fn( $row ) => 'update' === $row['action'] );
+    $to_create   = array_filter( $plan, static fn( $row ) => 'create' === $row['action'] );
+    $to_update   = array_filter( $plan, static fn( $row ) => 'update' === $row['action'] );
+    $to_backfill = array_filter( $plan, static fn( $row ) => 'backfill' === $row['product'] );
 
-    // Show the plan first so a dry run is genuinely informative.
-    $this->print_results( $plan, $format );
+    // Show the plan first so a dry run is genuinely informative. Only render the product
+    // column when a product flag is active, keeping the default output unchanged.
+    $this->print_results( $plan, $format, $create_products || $backfill_products );
     WP_CLI::log( sprintf(
       'Plan: %d to create, %d to update (name), %d unchanged.',
       count( $to_create ),
@@ -174,29 +214,39 @@ class Tier_Sync_Command {
       count( $plan ) - count( $to_create ) - count( $to_update )
     ) );
 
+    if ( $backfill_products ) {
+      WP_CLI::log( sprintf( '      + %d existing tier(s) to backfill with a product.', count( $to_backfill ) ) );
+    }
+
     if ( $dry_run ) {
       WP_CLI::success( 'Dry run complete — no changes written.' );
       return;
     }
 
-    if ( empty( $to_create ) && empty( $to_update ) ) {
+    if ( empty( $to_create ) && empty( $to_update ) && empty( $to_backfill ) ) {
       WP_CLI::success( 'Local tiers already in sync with the MDP.' );
       return;
     }
 
     // Gate the write behind an explicit confirmation unless --yes was passed.
-    WP_CLI::confirm(
-      sprintf( 'Create %d and update %d local tier(s)?', count( $to_create ), count( $to_update ) ),
-      $assoc_args
-    );
+    $confirm = sprintf( 'Create %d and update %d local tier(s)', count( $to_create ), count( $to_update ) );
 
-    $created = 0;
-    $updated = 0;
-    $errors  = 0;
+    if ( $backfill_products ) {
+      $confirm .= sprintf( ' and backfill %d with a product', count( $to_backfill ) );
+    }
+
+    WP_CLI::confirm( $confirm . '?', $assoc_args );
+
+    $created    = 0;
+    $updated    = 0;
+    $backfilled = 0;
+    $errors     = 0;
 
     foreach ( $plan as $row ) {
       if ( 'create' === $row['action'] ) {
-        $post_id = $this->create_tier( $row['mdp'], $config_id );
+        // create_tier mints and links the product inline when --create-products is on, so it
+        // can roll the product back if the tier insert fails.
+        $post_id = $this->create_tier( $row['mdp'], $config_id, $create_products );
 
         if ( is_wp_error( $post_id ) ) {
           WP_CLI::warning( sprintf( 'Failed to create "%s": %s', $row['name'], $post_id->get_error_message() ) );
@@ -211,9 +261,23 @@ class Tier_Sync_Command {
         ++$updated;
         WP_CLI::log( sprintf( 'Updated name on tier #%d to "%s".', $row['post_id'], $row['name'] ) );
       }
+
+      // Backfill a product onto an existing product-less tier. Independent of the name update
+      // above, since a tier can both drift in name and lack a product.
+      if ( 'backfill' === $row['product'] ) {
+        $result = $this->backfill_tier_product( (int) $row['post_id'], $row['uuid'], $row['name'] );
+
+        if ( is_wp_error( $result ) ) {
+          WP_CLI::warning( sprintf( 'Backfill failed for tier #%d "%s": %s', $row['post_id'], $row['name'], $result->get_error_message() ) );
+          ++$errors;
+        } else {
+          ++$backfilled;
+          WP_CLI::log( sprintf( 'Backfilled product #%d onto tier #%d "%s".', $result, $row['post_id'], $row['name'] ) );
+        }
+      }
     }
 
-    WP_CLI::success( sprintf( 'Done. Created %d, updated %d, errors %d.', $created, $updated, $errors ) );
+    WP_CLI::success( sprintf( 'Done. Created %d, updated %d, backfilled %d, errors %d.', $created, $updated, $backfilled, $errors ) );
   }
 
   /**
@@ -320,6 +384,20 @@ class Tier_Sync_Command {
   }
 
   /**
+   * Stop with an error unless WooCommerce Subscriptions is available.
+   *
+   * The product flags instantiate `WC_Product_Subscription`, so that class must exist. Fail
+   * closed before any write, mirroring the config and MDP-client preconditions.
+   *
+   * @return void
+   */
+  private function assert_subscriptions_available() {
+    if ( ! class_exists( '\WC_Product_Subscription' ) ) {
+      WP_CLI::error( 'WooCommerce Subscriptions is not active; --create-products / --backfill-products require it. Aborting.' );
+    }
+  }
+
+  /**
    * Fetch all membership tiers from the MDP, following pagination to completion.
    *
    * Uses the base plugin's `get_individual_memberships()` helper (GET `memberships`). The
@@ -372,16 +450,34 @@ class Tier_Sync_Command {
    * persisted before `save_post_wicket_mship_tier` fires, letting the existing slug hook
    * (`Helper::add_slug_on_mship_tier_create`) resolve `membership_tier_slug` correctly.
    *
-   * @param array<string, mixed> $mdp_tier   MDP tier resource object (`id` + `attributes`).
-   * @param int                  $config_id  Config post ID to attach.
+   * @param array<string, mixed> $mdp_tier         MDP tier resource object (`id` + `attributes`).
+   * @param int                  $config_id        Config post ID to attach.
+   * @param bool                 $create_products  When true, mint + link a subscription product.
    *
    * @return int|\WP_Error  New post ID on success, WP_Error on failure.
    */
-  private function create_tier( $mdp_tier, $config_id ) {
+  private function create_tier( $mdp_tier, $config_id, $create_products ) {
     $attributes = $mdp_tier['attributes'] ?? array();
     $tier_data  = $this->build_tier_data( $mdp_tier, $config_id );
 
-    return wp_insert_post( array(
+    // Track a product minted here so it can be rolled back if the tier insert fails, leaving
+    // no orphaned WooCommerce product behind. Zero means "nothing to roll back".
+    $created_product_id = 0;
+
+    if ( $create_products ) {
+      $product = $this->ensure_tier_product( $tier_data['mdp_tier_uuid'], $tier_data['mdp_tier_name'] );
+
+      // Abort the whole row on product failure rather than create a product-less tier the
+      // caller believes has one.
+      if ( is_wp_error( $product ) ) {
+        return $product;
+      }
+
+      $tier_data['product_data'] = $this->single_product_data( $product['id'], $tier_data['type'] );
+      $created_product_id        = $product['created'] ? $product['id'] : 0;
+    }
+
+    $post_id = wp_insert_post( array(
       'post_type'   => Helper::get_membership_tier_cpt_slug(),
       'post_title'  => $tier_data['mdp_tier_name'],
       'post_status' => 'publish',
@@ -392,6 +488,152 @@ class Tier_Sync_Command {
         'membership_tier_slug' => $attributes['slug'] ?? '',
       ),
     ), true );
+
+    // Roll back the just-created product if the tier could not be persisted (reused products
+    // are left alone — they may belong to another tier).
+    if ( is_wp_error( $post_id ) && $created_product_id ) {
+      wp_trash_post( $created_product_id );
+    }
+
+    return $post_id;
+  }
+
+  /**
+   * Create — or reuse — the simple subscription product that backs a tier.
+   *
+   * The SKU is derived deterministically from the tier UUID (`wicket-tier-<uuid>`), so a
+   * product is only ever created once per tier: a re-run, or a backfill following a create,
+   * finds the existing product by SKU and reuses it rather than duplicating. New products are
+   * created as a WooCommerce "simple subscription" with placeholder billing (yearly, price 0)
+   * that the admin adjusts afterward — the CLI's job is linkage, not pricing.
+   *
+   * @param string $uuid  The tier's `mdp_tier_uuid`, used to build the stable SKU.
+   * @param string $name  Product name/title; mirrors the tier name.
+   *
+   * @return array{id:int, created:bool}|\WP_Error  Product id plus whether it was freshly
+   *                                                 created, or WP_Error on failure.
+   */
+  private function ensure_tier_product( $uuid, $name ) {
+    if ( '' === (string) $uuid ) {
+      return new \WP_Error( 'wicket_mship_missing_uuid', 'Cannot build a tier product without a UUID.' );
+    }
+
+    // Deterministic SKU keyed on the tier UUID is what keeps product creation idempotent.
+    $sku         = 'wicket-tier-' . $uuid;
+    $existing_id = wc_get_product_id_by_sku( $sku );
+
+    if ( $existing_id ) {
+      return array(
+        'id'      => (int) $existing_id,
+        'created' => false,
+      );
+    }
+
+    $product = new \WC_Product_Subscription();
+    $product->set_name( (string) $name );
+    $product->set_sku( $sku );
+    $product->set_status( 'publish' );
+    $product->set_regular_price( '0' );
+    $product->set_price( '0' );
+
+    // Placeholder subscription terms — a valid yearly, never-expiring, free subscription the
+    // admin edits post-sync. WooCommerce Subscriptions reads these `_subscription_*` metas.
+    $product->update_meta_data( '_subscription_price', '0' );
+    $product->update_meta_data( '_subscription_period', 'year' );
+    $product->update_meta_data( '_subscription_period_interval', '1' );
+    $product->update_meta_data( '_subscription_length', '0' );
+    $product->update_meta_data( '_subscription_sign_up_fee', '0' );
+    $product->update_meta_data( '_subscription_trial_length', '0' );
+    $product->update_meta_data( '_subscription_trial_period', 'day' );
+
+    $product_id = $product->save();
+
+    if ( ! $product_id ) {
+      return new \WP_Error( 'wicket_mship_product_save_failed', sprintf( 'Failed to save a subscription product for "%s".', $name ) );
+    }
+
+    return array(
+      'id'      => (int) $product_id,
+      'created' => true,
+    );
+  }
+
+  /**
+   * Build a single-entry `product_data` array pointing at the given WC product.
+   *
+   * Individual tiers require `max_seats = -1`; organization tiers start at a nominal seat
+   * count of 1 that the admin can raise for per-seat tiers (see the seat-type notes in
+   * docs/engineering/wp-cli-tier-sync-plan.md §13.5). `variation_id` is 0 because a simple
+   * subscription has no variation — order→tier matching then falls back to the product id.
+   *
+   * @param int    $product_id  WooCommerce product ID to link.
+   * @param string $type        Tier type (`individual` | `organization`).
+   *
+   * @return array<int, array<string, int>>  A one-entry `product_data` list.
+   */
+  private function single_product_data( $product_id, $type ) {
+    // Individual tiers are validated to -1; org tiers seed a starting qty of 1.
+    $max_seats = ( 'individual' === $type ) ? -1 : 1;
+
+    return array(
+      array(
+        'product_id'   => (int) $product_id,
+        'variation_id' => 0,
+        'max_seats'    => $max_seats,
+      ),
+    );
+  }
+
+  /**
+   * Attach a subscription product to an existing tier that currently has none.
+   *
+   * Backs `--backfill-products`. Guards against clobbering: a tier that already has products
+   * is left untouched. Only `product_data` is written — every other `tier_data` field is
+   * preserved, making this the single sanctioned exception to the name-only update policy.
+   * If the meta write does not take, a product freshly created here is trashed so no orphan
+   * remains.
+   *
+   * @param int    $post_id  Existing tier post ID to backfill.
+   * @param string $uuid     The tier's `mdp_tier_uuid` (SKU key for the product).
+   * @param string $name     Product name/title; mirrors the tier name.
+   *
+   * @return int|\WP_Error  The linked product ID on success, WP_Error otherwise.
+   */
+  private function backfill_tier_product( $post_id, $uuid, $name ) {
+    $tier = new Membership_Tier( $post_id );
+
+    if ( ! is_array( $tier->tier_data ) ) {
+      return new \WP_Error( 'wicket_mship_bad_tier', sprintf( 'Tier #%d has no tier_data.', $post_id ) );
+    }
+
+    // Never overwrite an existing linkage — backfill only fills an empty gap.
+    if ( ! empty( $tier->get_products_data() ) ) {
+      return new \WP_Error( 'wicket_mship_has_products', sprintf( 'Tier #%d already has products.', $post_id ) );
+    }
+
+    $product = $this->ensure_tier_product( $uuid, $name );
+
+    if ( is_wp_error( $product ) ) {
+      return $product;
+    }
+
+    // Use the tier's stored type so backfilled seats match how the tier is actually configured.
+    $type                      = $tier->get_tier_type() ?: 'individual';
+    $tier_data                 = $tier->tier_data;
+    $tier_data['product_data'] = $this->single_product_data( $product['id'], $type );
+    $tier->update_tier_data( $tier_data );
+
+    // Verify the write landed (update_tier_data returns void); roll back a freshly-created
+    // product if it did not, so a failed backfill leaves no orphan.
+    if ( empty( ( new Membership_Tier( $post_id ) )->get_products_data() ) ) {
+      if ( $product['created'] ) {
+        wp_trash_post( $product['id'] );
+      }
+
+      return new \WP_Error( 'wicket_mship_backfill_failed', sprintf( 'Failed to write product_data to tier #%d.', $post_id ) );
+    }
+
+    return $product['id'];
   }
 
   /**
@@ -477,22 +719,56 @@ class Tier_Sync_Command {
   /**
    * Print the reconciliation plan/results table (drops the internal `mdp` payload column).
    *
-   * @param array<int, array<string, mixed>> $plan    Plan rows.
-   * @param string                           $format  WP-CLI output format.
+   * @param array<int, array<string, mixed>> $plan          Plan rows.
+   * @param string                           $format        WP-CLI output format.
+   * @param bool                             $show_product  Append the `product` column.
    *
    * @return void
    */
-  private function print_results( $plan, $format ) {
-    $rows = array_map( static function ( $row ) {
-      return array(
+  private function print_results( $plan, $format, $show_product ) {
+    $fields = array( 'action', 'type', 'name', 'uuid', 'post_id' );
+
+    // Only expose the product column when a product flag is active, so default runs keep
+    // their original columns unchanged.
+    if ( $show_product ) {
+      $fields[] = 'product';
+    }
+
+    $rows = array_map( function ( $row ) use ( $show_product ) {
+      $mapped = array(
         'action'  => $row['action'],
         'type'    => $row['type'],
         'name'    => $row['name'],
         'uuid'    => $row['uuid'],
         'post_id' => $row['post_id'],
       );
+
+      if ( $show_product ) {
+        $mapped['product'] = $this->format_product_cell( $row['product'] );
+      }
+
+      return $mapped;
     }, $plan );
 
-    Utils\format_items( $format, $rows, array( 'action', 'type', 'name', 'uuid', 'post_id' ) );
+    Utils\format_items( $format, $rows, $fields );
+  }
+
+  /**
+   * Map an internal product-action token to its results-table display label.
+   *
+   * @param string $product_action  One of `create`, `backfill`, `exists`, or `—`.
+   *
+   * @return string  Human-readable cell value.
+   */
+  private function format_product_cell( $product_action ) {
+    // Recognised tokens render as-is; anything else falls back to the em dash "no action".
+    switch ( $product_action ) {
+      case 'create':
+      case 'backfill':
+      case 'exists':
+        return $product_action;
+      default:
+        return '—';
+    }
   }
 }

--- a/includes/CLI/Tier_Sync_Command.php
+++ b/includes/CLI/Tier_Sync_Command.php
@@ -1,0 +1,498 @@
+<?php
+/**
+ * WP-CLI command for syncing membership tiers from the external Wicket MDP.
+ *
+ * @package Wicket
+ */
+
+namespace Wicket_Memberships\CLI;
+
+use Wicket_Memberships\Helper;
+use Wicket_Memberships\Membership_Tier;
+use WP_CLI;
+use WP_CLI\Utils;
+
+/**
+ * Creates local `wicket_mship_tier` posts from the tiers defined in the external MDP.
+ *
+ * Registered as `wp wicket-mship tier <subcommand>`. Reads the authoritative tier list
+ * from the MDP (via the base plugin's `get_individual_memberships()` helper) and reconciles
+ * it against local tier posts, creating any that are missing and linking them by
+ * `mdp_tier_uuid`. Product/renewal configuration is intentionally left to the admin UI —
+ * see docs/engineering/wp-cli-tier-sync-plan.md.
+ *
+ * @since 1.0.121
+ */
+class Tier_Sync_Command {
+
+  /**
+   * MDP page size used when paginating the `memberships` endpoint.
+   *
+   * The endpoint paginates JSON:API style; we request an explicit page size and follow
+   * `links.next` until it is null. 100 comfortably exceeds real-world tier counts, keeping
+   * this to a single round-trip in practice while remaining correct if it ever paginates.
+   *
+   * @var int
+   */
+  private const MDP_PAGE_SIZE = 100;
+
+  /**
+   * Hard cap on pages fetched, as a defensive guard against an unexpected pagination loop.
+   *
+   * @var int
+   */
+  private const MDP_MAX_PAGES = 100;
+
+  /**
+   * Create local membership tiers from the external MDP tiers.
+   *
+   * For each MDP tier: if a local tier already links to its UUID it is skipped (its name is
+   * refreshed if it drifted); otherwise a new `wicket_mship_tier` post is created linked by
+   * `mdp_tier_uuid` and attached to the config given by --config-id. Newly created tiers
+   * have no products — product selection is completed afterwards in the admin UI.
+   *
+   * ## OPTIONS
+   *
+   * --config-id=<post_id>
+   * : The `wicket_mship_config` post ID to attach to every created tier. Required because
+   * the MDP does not supply a config, and a tier is invalid without one. Environment
+   * specific — the same config has different IDs across sites.
+   *
+   * [--type=<type>]
+   * : Only sync tiers of this MDP type.
+   * ---
+   * default: all
+   * options:
+   *   - all
+   *   - individual
+   *   - organization
+   * ---
+   *
+   * [--dry-run]
+   * : Compute and print the plan without writing anything. Recommended first run.
+   *
+   * [--yes]
+   * : Skip the interactive confirmation before writing.
+   *
+   * [--format=<format>]
+   * : Output format for the results table.
+   * ---
+   * default: table
+   * options:
+   *   - table
+   *   - json
+   *   - csv
+   * ---
+   *
+   * ## EXAMPLES
+   *
+   *     # Preview what would be created against config post 123.
+   *     $ wp wicket-mship tier sync --config-id=123 --dry-run
+   *
+   *     # Create the missing tiers (prompts for confirmation).
+   *     $ wp wicket-mship tier sync --config-id=123
+   *
+   *     # Sync only organization tiers, no prompt.
+   *     $ wp wicket-mship tier sync --config-id=123 --type=organization --yes
+   *
+   * @param array<int, string>    $args        Positional args (unused).
+   * @param array<string, string> $assoc_args  Associative args from the flags above.
+   *
+   * @return void
+   */
+  public function sync( $args, $assoc_args ) {
+    $dry_run   = Utils\get_flag_value( $assoc_args, 'dry-run', false );
+    $type      = Utils\get_flag_value( $assoc_args, 'type', 'all' );
+    $format    = Utils\get_flag_value( $assoc_args, 'format', 'table' );
+    $config_id = (int) Utils\get_flag_value( $assoc_args, 'config-id', 0 );
+
+    // Fail before any MDP work if the config target is invalid — a tier cannot be saved
+    // without a valid config, so there is no point fetching tiers we could not create.
+    $this->assert_valid_config( $config_id );
+
+    // Confirm the MDP is reachable up front; creating tiers with a dead client would
+    // produce half-linked posts.
+    if ( ! $this->mdp_client_available() ) {
+      WP_CLI::error( 'MDP API client is not available (check Wicket settings/connectivity). Aborting.' );
+    }
+
+    WP_CLI::log( 'Fetching membership tiers from the MDP...' );
+    $mdp_tiers = $this->get_mdp_tiers();
+
+    if ( empty( $mdp_tiers ) ) {
+      WP_CLI::warning( 'No tiers returned from the MDP. Nothing to do.' );
+      return;
+    }
+
+    // Client-side type filter (the MDP `memberships` endpoint returns both types together).
+    if ( 'all' !== $type ) {
+      $mdp_tiers = array_values( array_filter( $mdp_tiers, static function ( $tier ) use ( $type ) {
+        return ( $tier['attributes']['type'] ?? '' ) === $type;
+      } ) );
+    }
+
+    // Build the reconciliation plan: create / skip / update, one row per MDP tier.
+    $plan = array();
+    foreach ( $mdp_tiers as $mdp_tier ) {
+      $uuid    = $mdp_tier['id'] ?? '';
+      $name    = $mdp_tier['attributes']['name_en'] ?? '';
+      $mdp_typ = $mdp_tier['attributes']['type'] ?? '';
+
+      if ( empty( $uuid ) ) {
+        continue; // Skip malformed entries with no UUID to link against.
+      }
+
+      $existing_id = Membership_Tier::get_tier_id_by_wicket_uuid( $uuid );
+
+      if ( false === $existing_id ) {
+        $action = 'create';
+      } else {
+        // Existing tier: only a name drift is actionable (update policy = name only).
+        $existing_name = ( new Membership_Tier( $existing_id ) )->get_mdp_tier_name();
+        $action        = ( $existing_name !== $name ) ? 'update' : 'skip';
+      }
+
+      $plan[] = array(
+        'action'  => $action,
+        'type'    => $mdp_typ,
+        'name'    => $name,
+        'uuid'    => $uuid,
+        'post_id' => $existing_id ?: '',
+        'mdp'     => $mdp_tier,
+      );
+    }
+
+    $to_create = array_filter( $plan, static fn( $row ) => 'create' === $row['action'] );
+    $to_update = array_filter( $plan, static fn( $row ) => 'update' === $row['action'] );
+
+    // Show the plan first so a dry run is genuinely informative.
+    $this->print_results( $plan, $format );
+    WP_CLI::log( sprintf(
+      'Plan: %d to create, %d to update (name), %d unchanged.',
+      count( $to_create ),
+      count( $to_update ),
+      count( $plan ) - count( $to_create ) - count( $to_update )
+    ) );
+
+    if ( $dry_run ) {
+      WP_CLI::success( 'Dry run complete — no changes written.' );
+      return;
+    }
+
+    if ( empty( $to_create ) && empty( $to_update ) ) {
+      WP_CLI::success( 'Local tiers already in sync with the MDP.' );
+      return;
+    }
+
+    // Gate the write behind an explicit confirmation unless --yes was passed.
+    WP_CLI::confirm(
+      sprintf( 'Create %d and update %d local tier(s)?', count( $to_create ), count( $to_update ) ),
+      $assoc_args
+    );
+
+    $created = 0;
+    $updated = 0;
+    $errors  = 0;
+
+    foreach ( $plan as $row ) {
+      if ( 'create' === $row['action'] ) {
+        $post_id = $this->create_tier( $row['mdp'], $config_id );
+
+        if ( is_wp_error( $post_id ) ) {
+          WP_CLI::warning( sprintf( 'Failed to create "%s": %s', $row['name'], $post_id->get_error_message() ) );
+          ++$errors;
+          continue;
+        }
+
+        ++$created;
+        WP_CLI::log( sprintf( 'Created tier #%d "%s" (%s).', $post_id, $row['name'], $row['uuid'] ) );
+      } elseif ( 'update' === $row['action'] ) {
+        $this->refresh_tier_name( (int) $row['post_id'], $row['name'] );
+        ++$updated;
+        WP_CLI::log( sprintf( 'Updated name on tier #%d to "%s".', $row['post_id'], $row['name'] ) );
+      }
+    }
+
+    WP_CLI::success( sprintf( 'Done. Created %d, updated %d, errors %d.', $created, $updated, $errors ) );
+  }
+
+  /**
+   * List membership tiers from either the MDP or the local site.
+   *
+   * A read-only helper to preview the MDP source list before syncing and to diff local
+   * tiers afterward. Writes nothing.
+   *
+   * ## OPTIONS
+   *
+   * [--source=<source>]
+   * : Where to read tiers from.
+   * ---
+   * default: mdp
+   * options:
+   *   - mdp
+   *   - local
+   * ---
+   *
+   * [--format=<format>]
+   * : Output format.
+   * ---
+   * default: table
+   * options:
+   *   - table
+   *   - json
+   *   - csv
+   *   - count
+   *   - ids
+   * ---
+   *
+   * ## EXAMPLES
+   *
+   *     $ wp wicket-mship tier list --source=mdp
+   *     $ wp wicket-mship tier list --source=local --format=json
+   *
+   * @subcommand list
+   *
+   * @param array<int, string>    $args        Positional args (unused).
+   * @param array<string, string> $assoc_args  Associative args from the flags above.
+   *
+   * @return void
+   */
+  public function list( $args, $assoc_args ) {
+    $source = Utils\get_flag_value( $assoc_args, 'source', 'mdp' );
+    $format = Utils\get_flag_value( $assoc_args, 'format', 'table' );
+
+    if ( 'local' === $source ) {
+      $rows = $this->get_local_tier_rows();
+    } else {
+      if ( ! $this->mdp_client_available() ) {
+        WP_CLI::error( 'MDP API client is not available (check Wicket settings/connectivity).' );
+      }
+      $rows = array();
+      foreach ( $this->get_mdp_tiers() as $tier ) {
+        $rows[] = array(
+          'uuid' => $tier['id'] ?? '',
+          'name' => $tier['attributes']['name_en'] ?? '',
+          'type' => $tier['attributes']['type'] ?? '',
+          'slug' => $tier['attributes']['slug'] ?? '',
+        );
+      }
+    }
+
+    if ( empty( $rows ) ) {
+      WP_CLI::warning( 'No tiers found.' );
+      return;
+    }
+
+    Utils\format_items( $format, $rows, array_keys( $rows[0] ) );
+  }
+
+  /**
+   * Validate that the given ID is a real membership config post, or stop with an error.
+   *
+   * Mirrors the guard the REST tier-save layer applies (`get_post()` + post-type check),
+   * so the CLI cannot attach a tier to a non-config post.
+   *
+   * @param int $config_id  Candidate config post ID.
+   *
+   * @return void
+   */
+  private function assert_valid_config( $config_id ) {
+    if ( $config_id <= 0 ) {
+      WP_CLI::error( '--config-id is required and must be a positive post ID.' );
+    }
+
+    $post = get_post( $config_id );
+
+    if ( ! $post || Helper::get_membership_config_cpt_slug() !== $post->post_type ) {
+      WP_CLI::error( sprintf( '--config-id %d is not a valid %s post.', $config_id, Helper::get_membership_config_cpt_slug() ) );
+    }
+  }
+
+  /**
+   * Determine whether a live MDP API client is available.
+   *
+   * @return bool True when `wicket_api_client()` returns a usable client.
+   */
+  private function mdp_client_available() {
+    // The base plugin exposes the client factory; it returns false when the SDK is missing
+    // or the connection/authorization fails.
+    return function_exists( 'wicket_api_client' ) && (bool) wicket_api_client();
+  }
+
+  /**
+   * Fetch all membership tiers from the MDP, following pagination to completion.
+   *
+   * Uses the base plugin's `get_individual_memberships()` helper (GET `memberships`). The
+   * endpoint returns both individual and organization tiers together and paginates JSON:API
+   * style, so we request an explicit page size and follow `links.next` until it is null.
+   *
+   * @return array<int, array<string, mixed>>  Flat list of MDP tier resource objects.
+   */
+  private function get_mdp_tiers() {
+    if ( ! function_exists( 'get_individual_memberships' ) ) {
+      WP_CLI::error( 'Base plugin helper get_individual_memberships() is unavailable.' );
+    }
+
+    $tiers = array();
+    $page  = 1;
+
+    do {
+      $response = get_individual_memberships( '', array(
+        'sort' => '-category_weight',
+        'page' => array(
+          'size'   => self::MDP_PAGE_SIZE,
+          'number' => $page,
+        ),
+      ) );
+
+      // The helper swallows exceptions and can return null on failure.
+      if ( empty( $response['data'] ) ) {
+        break;
+      }
+
+      foreach ( $response['data'] as $item ) {
+        $tiers[] = $item;
+      }
+
+      // Continue only while the MDP advertises a next page.
+      $has_next = ! empty( $response['links']['next'] );
+      ++$page;
+    } while ( $has_next && $page <= self::MDP_MAX_PAGES );
+
+    return $tiers;
+  }
+
+  /**
+   * Create a `wicket_mship_tier` post from an MDP tier resource.
+   *
+   * Writes a minimal, valid `tier_data` blob linked by `mdp_tier_uuid` and attached to the
+   * given config. `product_data` is intentionally empty — products are added later in the
+   * admin UI (a placeholder product id would fatal the tier admin, which loads each product
+   * via `wc_get_product()` unguarded). `tier_data` is passed through `meta_input` so it is
+   * persisted before `save_post_wicket_mship_tier` fires, letting the existing slug hook
+   * (`Helper::add_slug_on_mship_tier_create`) resolve `membership_tier_slug` correctly.
+   *
+   * @param array<string, mixed> $mdp_tier   MDP tier resource object (`id` + `attributes`).
+   * @param int                  $config_id  Config post ID to attach.
+   *
+   * @return int|\WP_Error  New post ID on success, WP_Error on failure.
+   */
+  private function create_tier( $mdp_tier, $config_id ) {
+    $attributes = $mdp_tier['attributes'] ?? array();
+    $tier_data  = $this->build_tier_data( $mdp_tier, $config_id );
+
+    return wp_insert_post( array(
+      'post_type'   => Helper::get_membership_tier_cpt_slug(),
+      'post_title'  => $tier_data['mdp_tier_name'],
+      'post_status' => 'publish',
+      'meta_input'  => array(
+        'tier_data' => $tier_data,
+        // Pre-seed the slug from the data we already hold, so it is correct even if the
+        // save_post hook's own lookup fails; the hook may re-set it to the same value.
+        'membership_tier_slug' => $attributes['slug'] ?? '',
+      ),
+    ), true );
+  }
+
+  /**
+   * Build the minimal `tier_data` array for a new tier from an MDP tier resource.
+   *
+   * @param array<string, mixed> $mdp_tier   MDP tier resource object.
+   * @param int                  $config_id  Config post ID to attach.
+   *
+   * @return array<string, mixed>  The `tier_data` meta value.
+   */
+  private function build_tier_data( $mdp_tier, $config_id ) {
+    $attributes = $mdp_tier['attributes'] ?? array();
+    $type       = ( 'organization' === ( $attributes['type'] ?? '' ) ) ? 'organization' : 'individual';
+
+    $tier_data = array(
+      'mdp_tier_uuid' => (string) ( $mdp_tier['id'] ?? '' ),
+      'mdp_tier_name' => (string) ( $attributes['name_en'] ?? '' ),
+      'config_id'     => (int) $config_id,
+      'type'          => $type,
+      // Sensible, benign default; the actual renewal path is configured in the admin UI.
+      'renewal_type'  => 'subscription',
+      // MDP 'approval' enum maps to the tier's approval flag; default off when not required.
+      'approval_required' => ( 'approval_required' === ( $attributes['approval'] ?? '' ) ) ? 1 : 0,
+      // No products yet — the admin selects the WooCommerce subscription product later.
+      'product_data'  => array(),
+    );
+
+    // Organization tiers carry a seat type derived from the MDP assignment model:
+    // unlimited_assignments=true -> range buckets; false -> per-seat (qty-driven).
+    if ( 'organization' === $type ) {
+      $tier_data['seat_type'] = ! empty( $attributes['unlimited_assignments'] ) ? 'per_range_of_seats' : 'per_seat';
+    }
+
+    return $tier_data;
+  }
+
+  /**
+   * Refresh only the `mdp_tier_name` on an existing tier (update policy = name only).
+   *
+   * @param int    $post_id  Existing tier post ID.
+   * @param string $name     New MDP name (`name_en`).
+   *
+   * @return void
+   */
+  private function refresh_tier_name( $post_id, $name ) {
+    $tier = new Membership_Tier( $post_id );
+
+    if ( ! is_array( $tier->tier_data ) ) {
+      return; // Malformed tier; leave untouched rather than risk clobbering it.
+    }
+
+    $tier_data                  = $tier->tier_data;
+    $tier_data['mdp_tier_name'] = (string) $name;
+    $tier->update_tier_data( $tier_data );
+  }
+
+  /**
+   * Build display rows for local tier posts.
+   *
+   * @return array<int, array<string, mixed>>  One row per local tier.
+   */
+  private function get_local_tier_rows() {
+    $posts = get_posts( array(
+      'post_type'      => Helper::get_membership_tier_cpt_slug(),
+      'posts_per_page' => -1,
+      'post_status'    => 'any',
+    ) );
+
+    $rows = array();
+    foreach ( $posts as $post ) {
+      $tier = new Membership_Tier( $post->ID );
+      $rows[] = array(
+        'post_id' => $post->ID,
+        'name'    => $tier->get_mdp_tier_name(),
+        'type'    => $tier->get_tier_type(),
+        'uuid'    => $tier->get_mdp_tier_uuid(),
+      );
+    }
+
+    return $rows;
+  }
+
+  /**
+   * Print the reconciliation plan/results table (drops the internal `mdp` payload column).
+   *
+   * @param array<int, array<string, mixed>> $plan    Plan rows.
+   * @param string                           $format  WP-CLI output format.
+   *
+   * @return void
+   */
+  private function print_results( $plan, $format ) {
+    $rows = array_map( static function ( $row ) {
+      return array(
+        'action'  => $row['action'],
+        'type'    => $row['type'],
+        'name'    => $row['name'],
+        'uuid'    => $row['uuid'],
+        'post_id' => $row['post_id'],
+      );
+    }, $plan );
+
+    Utils\format_items( $format, $rows, array( 'action', 'type', 'name', 'uuid', 'post_id' ) );
+  }
+}

--- a/includes/Import_Controller.php
+++ b/includes/Import_Controller.php
@@ -22,7 +22,11 @@ class Import_Controller {
 
   public function create_individual_memberships( $record ) {
           $options = get_option( 'wicket_membership_plugin_options' );
+          // "Every membership" option: create a subscription for all imported memberships.
           $create_subscription_on_import = !empty( $options['wicket_mship_import_create_subscriptions'] ) ? true : false;
+          // "Tier subscription only" option: create a subscription only when the tier renews via subscription.
+          // Defaults to enabled (opt-out) when never saved, preserving the legacy subscription-tier import behaviour.
+          $create_subscription_tier_only = isset( $options['wicket_mship_import_create_subscriptions_tier_only'] ) ? !empty( $options['wicket_mship_import_create_subscriptions_tier_only'] ) : true;
 
           if(empty($record)) {
             return 'File line read error.';
@@ -121,7 +125,8 @@ class Import_Controller {
           } 
 
           //if this is a subscription renewal tier import we need to create the placeholder subscription for reference when renewing
-          if( $is_active_membership && ($create_subscription_on_import || $membership_tier_array['renewal_type'] == 'subscription' )) {
+          // Three-state behaviour: "every membership" wins outright; otherwise "tier only" requires a subscription-renewal tier; both off creates nothing.
+          if( $is_active_membership && ($create_subscription_on_import || ( $create_subscription_tier_only && $membership_tier_array['renewal_type'] == 'subscription' ) )) {
             $subscription_id = $this->createSubscriptionForRenewal( $membership_post_mapping, $membership_id );
             $response .= ' Subscription created ID# '.$subscription_id;
           }
@@ -131,7 +136,11 @@ class Import_Controller {
 
         public function create_organization_memberships( $record ) {
           $options = get_option( 'wicket_membership_plugin_options' );
+          // "Every membership" option: create a subscription for all imported memberships.
           $create_subscription_on_import = !empty( $options['wicket_mship_import_create_subscriptions'] ) ? true : false;
+          // "Tier subscription only" option: create a subscription only when the tier renews via subscription.
+          // Defaults to enabled (opt-out) when never saved, preserving the legacy subscription-tier import behaviour.
+          $create_subscription_tier_only = isset( $options['wicket_mship_import_create_subscriptions_tier_only'] ) ? !empty( $options['wicket_mship_import_create_subscriptions_tier_only'] ) : true;
 
           if(empty($record)) {
             return 'File line read error.';
@@ -230,7 +239,8 @@ class Import_Controller {
           } 
           
           //if this is a subscription renewal tier import we need to create the placeholder subscription for reference when renewing
-          if( $is_active_membership && ($create_subscription_on_import || $membership_tier_array['renewal_type'] == 'subscription' )) {
+          // Three-state behaviour: "every membership" wins outright; otherwise "tier only" requires a subscription-renewal tier; both off creates nothing.
+          if( $is_active_membership && ($create_subscription_on_import || ( $create_subscription_tier_only && $membership_tier_array['renewal_type'] == 'subscription' ) )) {
             $subscription_id = $this->createSubscriptionForRenewal( $membership_post_mapping, $membership_id );
             $response .= ' Subscription created ID# '.$subscription_id;
           }

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -329,6 +329,16 @@ class Settings {
         <p style="color:black;font-style:italic">4. Follow guidance to add the correct args. Import is batched, wait until complete or run as a background task!</p>
         <p style="color:black;font-style:italic">5. Can be run locally to populate a remote server by pointing the <code>api_domain</code> to the remote site with plugin installed!</p>
         <p style="color:black;font-style:italic"><code>php ./csv_import_threads.php { individual|organization } { file_path from /uploads/ } { api_domain - optional str } { skip_approval - optional bool }</code></p>
+        <?php
+          // The subscription sync tool is loaded from wicket.php only while MDP Import
+          // (this setting) is enabled, so its link is surfaced here alongside the import steps.
+          $sync_tool_url = esc_url( home_url( '/?mship_subscription_sync=1' ) );
+        ?>
+        <p style="color:#b32d2e;font-style:italic;margin-top:10px;border-top:1px solid #eee;padding-top:10px;">
+            <strong>Note — reusing existing subscriptions:</strong> When importing memberships <em>without</em> creating new subscriptions, and you want imported memberships to attach to subscriptions that already exist, use the Subscription Sync tool to link them. It walks active/on-hold subscriptions and links each to its matching membership record. For each subscription it looks for a current membership belonging to the same user (matched by email) on the same tier (resolved from the product assigned to the subscription).
+            <br>This tool is only available while <strong>MDP Import</strong> (this setting) is enabled.
+            <br><a target="_blank" rel="noopener" href="<?php echo $sync_tool_url; ?>">Open the Subscription Sync tool in a new tab &#8599;</a>
+        </p>
     </div>
     <script>
     document.addEventListener('DOMContentLoaded', function() {

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -25,6 +25,9 @@ class Settings {
     <form action="options.php" method="post">
     <h2>Wicket Membership Settings</h2>
     <?php
+      // Surface active local-import / sync-tool state at the top of the page so admins
+      // are not surprised that command-line import endpoints or the sync tool are live.
+      Settings::wicket_membership_render_environment_notices();
       Settings::check_migrate_tier_slugs();
       settings_fields( 'wicket_membership_plugin_options' );
       do_settings_sections( 'wicket_membership_plugin' ); ?>
@@ -32,6 +35,49 @@ class Settings {
     <a href="edit.php?post_type=wicket_membership" target="_blank"><input class="button button-secondary" type="button" value="View Raw Membership Posts"/></a></p>
     </form>
     <?php
+  }
+
+  /**
+   * Renders warning notices at the top of the settings page for active local-import state.
+   *
+   * Two independent conditions are surfaced because they have real security/operational
+   * implications and are easy to leave enabled unintentionally:
+   *  - ALLOW_LOCAL_IMPORTS is on, exposing the command-line CSV import tooling.
+   *  - The memberships-sync.php tool is actively included (its function is defined),
+   *    meaning the browser-triggered subscription sync endpoint is reachable.
+   *
+   * The sync tool is loaded from wicket.php whenever the `allow_local_imports` option key
+   * exists, so detecting the function presence is the only reliable "is it live" signal.
+   *
+   * @see wicket_sync_subscriptions() Defined in custom/memberships-sync.php when included.
+   *
+   * @return void
+   */
+  public static function wicket_membership_render_environment_notices() {
+    $options = get_option( 'wicket_membership_plugin_options' );
+
+    // Local imports flagged on — command-line CSV import endpoints are enabled.
+    $local_imports_enabled = ! empty( $options['allow_local_imports'] );
+
+    // The sync tool defines this function only when custom/memberships-sync.php is included.
+    $sync_tool_active = function_exists( 'wicket_sync_subscriptions' );
+
+    if ( ! $local_imports_enabled && ! $sync_tool_active ) {
+      return;
+    }
+
+    echo '<div class="notice notice-warning" style="margin:15px 0;padding:10px 12px;">';
+    echo '<p style="margin-top:0;"><strong>&#9888; Local Import / Sync Tooling Active</strong></p>';
+
+    if ( $local_imports_enabled ) {
+      echo '<p style="margin:6px 0;"><strong>ALLOW_LOCAL_IMPORTS is enabled.</strong> Command-line CSV import tooling is active. This should remain disabled in production unless an import is actively in progress.</p>';
+    }
+
+    if ( $sync_tool_active ) {
+      echo '<p style="margin:6px 0;"><strong>The memberships-sync tool (<code>custom/memberships-sync.php</code>) is actively included.</strong> The browser-triggered subscription sync endpoint (<code>?mship_subscription_sync=1</code>) is reachable. See the import instructions below for how to use the sync tool safely.</p>';
+    }
+
+    echo '</div>';
   }
 
   public function get_next_scheduled_membership_activation() {
@@ -88,7 +134,8 @@ class Settings {
     add_settings_field( 'bypass_status_change_lockout', '<p>BYPASS_STATUS_CHANGE_LOCKOUT</p>', [__NAMESPACE__.'\\Settings', 'bypass_status_change_lockout'], 'wicket_membership_plugin', 'debug_settings' );
     add_settings_field( 'wicket_show_order_debug_data', '<p>WICKET_SHOW_ORDER_DEBUG_DATA</p>', [__NAMESPACE__.'\\Settings', 'wicket_show_order_debug_data'], 'wicket_membership_plugin', 'debug_settings' );
     add_settings_field( 'allow_local_imports', '<p>ALLOW_LOCAL_IMPORTS</p>', [__NAMESPACE__.'\\Settings', 'allow_local_imports'], 'wicket_membership_plugin', 'debug_settings' );
-    add_settings_field( 'wicket_mship_import_create_subscriptions', '<p style="color:#999">Import Subscription Option:</p>', [__NAMESPACE__.'\\Settings', 'wicket_mship_import_create_subscriptions'], 'wicket_membership_plugin', 'debug_settings' );
+    add_settings_field( 'wicket_mship_import_create_subscriptions_tier_only', '<p style="color:#999">Import Subscription Option:</p>', [__NAMESPACE__.'\\Settings', 'wicket_mship_import_create_subscriptions_tier_only'], 'wicket_membership_plugin', 'debug_settings' );
+    add_settings_field( 'wicket_mship_import_create_subscriptions', '', [__NAMESPACE__.'\\Settings', 'wicket_mship_import_create_subscriptions'], 'wicket_membership_plugin', 'debug_settings' );
     add_settings_field( 'wicket_memberships_debug_renew', '<p>WICKET_MEMBERSHIPS_DEBUG_RENEW</p>', [__NAMESPACE__.'\\Settings', 'wicket_memberships_debug_renew'], 'wicket_membership_plugin', 'debug_settings' );
     add_settings_field( 'wicket_memberships_debug_cart_ids', '<p>WICKET_MEMBERSHIPS_DEBUG_CART_IDS</p>', [__NAMESPACE__.'\\Settings', 'wicket_memberships_debug_cart_ids'], 'wicket_membership_plugin', 'debug_settings' );
     add_settings_field( 'bypass_wicket', '<p>BYPASS_WICKET</p>', [__NAMESPACE__.'\\Settings', 'bypass_wicket'], 'wicket_membership_plugin', 'debug_settings' );
@@ -199,10 +246,45 @@ class Settings {
 
   }
   
+  /**
+   * Renders the "tier subscription only" import option checkbox.
+   *
+   * This is the middle of three mutually understood import-subscription states:
+   *   - Neither this nor the "every membership" option checked -> no subscriptions on import.
+   *   - This checked -> only memberships whose Tier renewal type is "Subscription" get one.
+   *   - The "every membership" option checked -> all imported memberships get one (overrides this).
+   *
+   * Defaults to enabled (opt-out) when never saved, preserving the legacy behaviour where
+   * subscription-renewal tiers always received a subscription on import.
+   *
+   * @see wicket_mship_import_create_subscriptions() The broader "every membership" option.
+   * @see Import_Controller::create_individual_memberships() Consumes both options.
+   *
+   * @return void
+   */
+  public static function wicket_mship_import_create_subscriptions_tier_only() {
+    $options = get_option( 'wicket_membership_plugin_options' );
+    // Default to checked when the option has never been saved, preserving legacy import behaviour.
+    $value = isset( $options['wicket_mship_import_create_subscriptions_tier_only'] ) ? $options['wicket_mship_import_create_subscriptions_tier_only'] : 1;
+    echo "<input id='wicket_mship_import_create_subscriptions_tier_only' name='wicket_membership_plugin_options[wicket_mship_import_create_subscriptions_tier_only]' type='checkbox' value='1' ".checked(1, esc_attr( $value ), false). " />"
+      .'Create a WooCommerce Subscription only for imported memberships created in a Tier with their renewal type = "Subscription". <p>Enabled by default. Uncheck both subscription options to import without creating any subscriptions.</p>';
+  }
+
+  /**
+   * Renders the "every imported membership" subscription option checkbox.
+   *
+   * When checked this overrides the tier-only option and creates a subscription for
+   * every imported membership regardless of its Tier renewal type. See
+   * wicket_mship_import_create_subscriptions_tier_only() for the three-state behaviour.
+   *
+   * @see wicket_mship_import_create_subscriptions_tier_only() The narrower tier-only option.
+   *
+   * @return void
+   */
   public static function wicket_mship_import_create_subscriptions() {
     $options = get_option( 'wicket_membership_plugin_options' );
     echo "<input id='wicket_mship_import_create_subscriptions' name='wicket_membership_plugin_options[wicket_mship_import_create_subscriptions]' type='checkbox' value='1' ".checked(1, esc_attr( $options['wicket_mship_import_create_subscriptions']), false). " />"
-      .'Create a WooCommerce Subscription for every imported membership, regardless of tier renewal type. <p>By default only Memberships created in a Tier with their renewal type = "Subscription" will have subscriptions created on import.</p>';
+      .'Create a WooCommerce Subscription for every imported membership, regardless of tier renewal type.';
   }
 
   public static function wicket_mship_subscription_renew() {
@@ -245,6 +327,7 @@ class Settings {
         <p style="color:black;font-style:italic">2. Upload Membership CSV to media folder. Separate files for Individuals and Organizations.</p>
         <p style="color:black;font-style:italic">3. Run the import command from the ssh command line in the plugin folder: <code>php ./csv_import_threads.php</code>.</p>
         <p style="color:black;font-style:italic">4. Follow guidance to add the correct args. Import is batched, wait until complete or run as a background task!</p>
+        <p style="color:black;font-style:italic">5. Can be run locally to populate a remote server by pointing the <code>api_domain</code> to the remote site with plugin installed!</p>
         <p style="color:black;font-style:italic"><code>php ./csv_import_threads.php { individual|organization } { file_path from /uploads/ } { api_domain - optional str } { skip_approval - optional bool }</code></p>
     </div>
     <script>
@@ -300,6 +383,7 @@ class Settings {
     $newinput['bypass_wicket'] = trim($input['bypass_wicket']);
     $newinput['wicket_mship_subscription_renew'] = trim($input['wicket_mship_subscription_renew']); 
     $newinput['wicket_mship_mdp_timezone'] = trim($input['wicket_mship_mdp_timezone']);
+    $newinput['wicket_mship_import_create_subscriptions_tier_only'] = trim($input['wicket_mship_import_create_subscriptions_tier_only']);
     $newinput['wicket_mship_import_create_subscriptions'] = trim($input['wicket_mship_import_create_subscriptions']);
     $newinput['wicket_show_mship_order_org_search'] = is_array($input['wicket_show_mship_order_org_search']) ? $input['wicket_show_mship_order_org_search'] : [];
     if(!empty($_REQUEST['schedule_daily_membership_expiry_hook'])) {

--- a/wicket.php
+++ b/wicket.php
@@ -423,5 +423,11 @@ if ( ! class_exists( 'Wicket_Memberships' ) ) {
 
 	} // end Class Wicket_Memberships.
 	new Wicket_Memberships();
+
+	// Register WP-CLI commands. Guarded so this never runs during a normal web request;
+	// the class autoloads via the composer PSR-4 map (Wicket_Memberships\ => includes/).
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		\WP_CLI::add_command( 'wicket-mship tier', \Wicket_Memberships\CLI\Tier_Sync_Command::class );
+	}
 }
 

--- a/wicket.php
+++ b/wicket.php
@@ -110,8 +110,8 @@ if ( ! class_exists( 'Wicket_Memberships' ) ) {
           if(isset($options['allow_local_imports'])) {
             if($options['allow_local_imports']) {
               $_ENV['ALLOW_LOCAL_IMPORTS']=true;
+              require_once( WP_PLUGIN_DIR . '/wicket-wp-memberships/custom/memberships-sync.php' );
             }
-            //require_once( WP_PLUGIN_DIR . '/wicket-wp-memberships/custom/memberships-sync.php' );
           }
           if(isset($options['wicket_memberships_debug_cart_ids'])) {
             if($options['wicket_memberships_debug_cart_ids']) {


### PR DESCRIPTION
**Memberships need to be attached to existing subscription for in-situ site migrations** or sometimes when a customer wants to launch with existing subscriptions with particular properties for their memberships. 

- includes the membership sync tool in the path only when the MDP imports are enabled
- extend membership import options to skip all subscription creation (necessary when existing)
- provide an enhanced UI to perform the membership sync to existing subscriptions when enabled
- provide some guidance and the direct link in the Settings > Wicket Membership import info (click red ?)
- publish engineering and guidance docs

When enabled the sync tool will load when going to the admin url with query string ` ?mship_subscription_sync=1`

Previously this script was customised and run from the child theme for each client.

The code has matured to the point where it  was extensive enough to be useful on most sites and is being packaged in the plugin to be available when necessary with no additional effort. The UI was created so knowledge of the query string variables is unnecessary.