### PR TITLE
feat(tiers): capability-gated carry-over toggle and seat-count overflow retry

### DIFF
--- a/includes/Membership_Controller.php
+++ b/includes/Membership_Controller.php
@@ -1133,6 +1133,20 @@ function get_item_data ( $other_data, $cart_item ) {
               $Tier->is_grant_owner_assignment(),
               false
             );
+            // Defensive: log the retry outcome so QA can see whether the
+            // copy=false retry recovered or also failed. A failed retry still
+            // surfaces to the shared error handler below; this log names it.
+            if ( is_wp_error( $response ) ) {
+              Utilities::wc_log_mship_error( [ 'carry-over overflow: copy=false retry ALSO failed', $previous_membership_wicket_uuid, 'error' => $response->get_error_message( 'wicket_api_error' ) ] );
+            } else {
+              Utilities::wc_log_mship_error( [ 'carry-over overflow: copy=false retry succeeded, assignments not carried', $previous_membership_wicket_uuid ] );
+            }
+          } elseif ( is_wp_error( $response ) && $carry ) {
+            // Defensive: first attempt failed while we intended to copy, but it
+            // was NOT the max_assignments overflow. Surfaces the actual error so
+            // QA can distinguish a detection miss (overflow we didn't flag) from
+            // a genuinely different failure (auth, unrelated validation, etc.).
+            Utilities::wc_log_mship_error( [ 'carry-over first attempt failed (non-overflow, no retry)', $previous_membership_wicket_uuid, 'carry' => $carry, 'error' => $response->get_error_message( 'wicket_api_error' ) ] );
           }
         } elseif( $base_version_supports_grant_owner_assignment ) {
           $Tier = new Membership_Tier( $membership['membership_tier_post_id'] );

--- a/includes/Membership_Controller.php
+++ b/includes/Membership_Controller.php
@@ -1052,7 +1052,11 @@ function get_item_data ( $other_data, $cart_item ) {
   public function create_mdp_record( $membership ) {
     $base_version_supports_previous_membership_assignment = version_compare( $_ENV['WICKET_BASE_PLUGIN_VERSION'], '2.0.52', '>' );
     $base_version_supports_grant_owner_assignment = version_compare( $_ENV['WICKET_BASE_PLUGIN_VERSION'], '2.0.108', '>' );
-    $base_version_supports_copy_active_assignments = version_compare( $_ENV['WICKET_BASE_PLUGIN_VERSION'], '2.4.10', '>' );
+    // Capability gate (not version-gated): the base plugin ships a registry
+    // helper when it supports the copy_previous_assignments param. See atlas
+    // ADR 0004 / conventions/capability-detection.md.
+    $base_version_supports_copy_active_assignments = function_exists( 'wicket_supports' )
+      && wicket_supports( 'base-plugin.organization_membership.copy_previous_assignments' );
 
     $previous_membership_wicket_uuid = '';
     if(!empty($membership['previous_membership_post_id'])) {
@@ -1094,6 +1098,7 @@ function get_item_data ( $other_data, $cart_item ) {
         }
         if( $base_version_supports_copy_active_assignments ) {
           $Tier = new Membership_Tier( $membership['membership_tier_post_id'] );
+          $carry = $Tier->copy_active_assignments_on_renewal();
           $response = wicket_assign_organization_membership(
             $membership['person_uuid'],
             $membership['organization_uuid'],
@@ -1104,8 +1109,31 @@ function get_item_data ( $other_data, $cart_item ) {
             $membership['membership_grace_period_days'],
             $previous_membership_wicket_uuid,
             $Tier->is_grant_owner_assignment(),
-            $Tier->copy_active_assignments_on_renewal()
+            $carry
           );
+          // Seat-count overflow safety net (WWID-1908): if the MDP rejected the
+          // create because carrying assignments over would exceed the new tier's
+          // max_assignments and we tried to copy, retry once without copying. The
+          // overflow flag is set by the base plugin in error_data under the
+          // existing 'wicket_api_error' code; ?? false self-gates on older base.
+          // Idempotent: the failed first attempt creates nothing in the MDP
+          // (validation precedes save), and copy=false means no assignments to
+          // count, so the retry cannot loop on the same error.
+          if ( is_wp_error( $response ) && $carry && ( $response->get_error_data( 'wicket_api_error' )['overflow'] ?? false ) ) {
+            Utilities::wc_log_mship_error( [ 'carry-over overflow; retrying without copy', $previous_membership_wicket_uuid, 'seats' => $membership['membership_seats'] ] );
+            $response = wicket_assign_organization_membership(
+              $membership['person_uuid'],
+              $membership['organization_uuid'],
+              $membership['membership_tier_uuid'],
+              $membership['membership_starts_at'],
+              $membership['membership_ends_at'],
+              $membership['membership_seats'],
+              $membership['membership_grace_period_days'],
+              $previous_membership_wicket_uuid,
+              $Tier->is_grant_owner_assignment(),
+              false
+            );
+          }
         } elseif( $base_version_supports_grant_owner_assignment ) {
           $Tier = new Membership_Tier( $membership['membership_tier_post_id'] );
           $response = wicket_assign_organization_membership(


### PR DESCRIPTION
## What

Converts the carry-over gate from the broken `version_compare` placeholder to the `wicket_supports()` capability registry, and adds the WWID-1908 seat-count overflow retry. One file, `includes/Membership_Controller.php`, +30/-2.

T4 (the `copy_active_assignments_on_renewal()` accessor) and T5 (the React org-tier checkbox) already shipped via #50. This PR lands the two pieces that did not: the capability gate (T3) and the overflow retry (T7).

## Why

PR #50 shipped the carry-over toggle with a `version_compare( $_ENV['WICKET_BASE_PLUGIN_VERSION'], '2.4.10', '>' )` gate. That tag is a guess. The release bot assigns it at merge time, so it can never be confirmed while the PR is open, and a wrong guess dead-codes the branch silently. Capability detection answers "is this supported here?" at runtime, from the installed base. The gate is also mandatory for the new-param case because PHP silently drops extra arguments: without it, an admin who toggles carry-over OFF on a site whose base plugin has not updated silently keeps the old copy-always behavior.

WWID-1908 stops the membership record from breaking its sync with the MDP when an org renews into a tier with fewer seats than it has people assigned. Trust the MDP as the sole authority on its own threshold, retry without copy on the specific overflow error.

## How

- Gate is now `function_exists( 'wicket_supports' ) && wicket_supports( 'base-plugin.organization_membership.copy_previous_assignments' )`. Old base returns `false`, the legacy 9-arg path runs, current behavior is preserved.
- Retry reads `$response->get_error_data( 'wicket_api_error' )['overflow'] ?? false`. The `?? false` is the entire gate for the 1908 side: no version check, no capability key, no extra round trip. Idempotent because the failed first attempt creates nothing in the MDP (validation fires before save), and `copy=false` means nothing to count, so the retry cannot loop on the same error.

## Depends on

The base-plugin PR that ships the `wicket_supports()` registry with the `base-plugin.organization_membership.copy_previous_assignments` key, the `$copy_previous_assignments` 10th param, and the overflow flag in `error_data`. Functional in the wild only after that PR merges and tags. https://github.com/industrialdev/wicket-wp-base-plugin/pull/14

## Testing

- [x] `php -l` clean.
- [x] Warden WordPress-integration test: stub `wicket_assign_organization_membership` via the `wicket_pre_assign_organization_membership` filter to return overflow on first call, success on second. Assert retry fires with `copy=false`, second response used. Non-overflow error asserts no retry. `$carry=false` asserts single `copy=false` attempt, no retry even on error.
- [x] Manual on staging: org with assignments exceeding new tier max, renew with toggle on. Renewed membership syncs, 0 copied, log entry present.

## Notes

- No change when carry-over is disabled. That path sends `copy=false` on the first attempt, and the retry guard (`&& $carry`) never fires.
- Individual/person tiers never reach the org renewal branch.
- The two existing version-gated rungs (2.0.52, 2.0.108) stay as history. Not retro-migrated.

Related: WWID-1906, WWID-1908.
