### PR TITLE
Fix: renewal cart URL ignores active language (WWID-1992)

### DIFF
--- a/includes/Membership_Controller.php
+++ b/includes/Membership_Controller.php
@@ -1897,7 +1897,7 @@ function get_item_data ( $other_data, $cart_item ) {
               $query_string = $parts['query'];
             }
           }
-          $renewal_link_url = '/cart/?' . $query_string;
+          $renewal_link_url = wc_get_cart_url() . '?' . $query_string;
           $this->wicket_update_subscription_meta_membership_post_id(  $membership_data['ID'], $membership_data['meta'] );
         } elseif( empty($renewal_link_url) && $current_time < strtotime($membership_data['meta']['membership_expires_at']) /* !empty( $the_order) /*&& $the_order->ID != $membership_data['meta']['membership_parent_order_id']*/) {
           //$the_order->update_status('on-hold', __('Order status changed generating a pending renewal order.'));


### PR DESCRIPTION
## What
Replaced a hardcoded `/cart/` path with `wc_get_cart_url()` when building the early-renewal cart redirect link.

## Why
The renewal call-out's cart link ignored the visitor's active language, so French visitors were always sent to the English cart URL instead of the French one.

## How
`wc_get_cart_url()` is WPML/WooCommerce Multilingual-aware and returns the cart URL in the current language, replacing the language-agnostic hardcoded string.

## Testing
- [x] On an active subscription-based membership within its early-renewal window, trigger the renewal call-out while browsing in French and confirm the link lands on the French cart URL (not /cart/).
- [x] Confirm English renewal flow still works unchanged.
- [x] Purge page cache (Breeze) before testing to avoid stale cached markup.

---
Asana: WWID-1992 — https://app.asana.com/1/1138832104141584/project/1216279585352304/task/1216633136670480