### PR TITLE
fix: normalize calendar season dates and fix bare-date timezone shift

### DIFF
--- a/includes/Membership_Post_Types.php
+++ b/includes/Membership_Post_Types.php
@@ -284,6 +284,12 @@ class Membership_Post_Types {
           'type'        => 'object',
           'description' => 'Late Fee Window Data',
           'arg_options' => [
+            'sanitize_callback' => function( $value ) {
+              if ( is_array( $value ) && ( $value['cycle_type'] ?? null ) === 'calendar' && is_array( $value['calendar_items'] ?? null ) ) {
+                $value['calendar_items'] = $this->normalize_calendar_season_dates( $value['calendar_items'] );
+              }
+              return $value;
+            },
             'validate_callback' => function( $value ) {
               $errors = new WP_Error();
 
@@ -316,6 +322,11 @@ class Membership_Post_Types {
                 if ( ! is_array( $value['calendar_items'] ) ) {
                   $errors->add( 'rest_invalid_param_calendar_items', __( 'The calendar items must be an array.', 'wicket-memberships' ), array( 'status' => 400 ) );
                 }
+
+                // Normalize dates for validation so legacy/partial season data
+                // (e.g. bare Y-m-d dates missing a time component) is checked
+                // against the same day boundaries that will actually be stored.
+                $value['calendar_items'] = $this->normalize_calendar_season_dates( $value['calendar_items'] );
 
                 if ( count( $value['calendar_items'] ) < 1 ) {
                   $errors->add( 'rest_invalid_param_calendar_items', __( 'At least one season item must be defined.', 'wicket-memberships' ), array( 'status' => 400 ) );
@@ -1116,6 +1127,35 @@ class Membership_Post_Types {
           ],
       ]);
     });
+  }
+
+  /**
+   * Normalize calendar season start/end dates to the start/end of day in the
+   * MDP timezone (converted to UTC), so partial or legacy season data (e.g.
+   * bare Y-m-d dates with no time component) always ends up with consistent
+   * day boundaries. Without this, a season saved before this convention
+   * existed keeps a bare date forever, since the admin UI only re-derives a
+   * season's dates when that specific season's date picker is touched.
+   *
+   * @param array $calendar_items List of season items with start_date/end_date.
+   * @return array Season items with normalized start_date/end_date.
+   */
+  private function normalize_calendar_season_dates( $calendar_items ) {
+    if ( ! is_array( $calendar_items ) ) {
+      return $calendar_items;
+    }
+
+    foreach ( $calendar_items as $key => $item ) {
+      if ( ! empty( $item['start_date'] ) ) {
+        $calendar_items[ $key ]['start_date'] = Utilities::get_mdp_day_start( $item['start_date'] )->format( 'c' );
+      }
+
+      if ( ! empty( $item['end_date'] ) ) {
+        $calendar_items[ $key ]['end_date'] = Utilities::get_mdp_day_end( $item['end_date'] )->format( 'c' );
+      }
+    }
+
+    return $calendar_items;
   }
 
 }

--- a/includes/Membership_Post_Types.php
+++ b/includes/Membership_Post_Types.php
@@ -1147,11 +1147,21 @@ class Membership_Post_Types {
 
     foreach ( $calendar_items as $key => $item ) {
       if ( ! empty( $item['start_date'] ) ) {
-        $calendar_items[ $key ]['start_date'] = Utilities::get_mdp_day_start( $item['start_date'] )->format( 'c' );
+        try {
+          $calendar_items[ $key ]['start_date'] = Utilities::get_mdp_day_start( $item['start_date'] )->format( 'c' );
+        } catch ( \InvalidArgumentException $e ) {
+          // Leave the raw, unparseable value in place. The validate_callback's
+          // strtotime()/empty() checks below will reject it with a normal 400
+          // instead of this normalization step throwing a fatal 500.
+        }
       }
 
       if ( ! empty( $item['end_date'] ) ) {
-        $calendar_items[ $key ]['end_date'] = Utilities::get_mdp_day_end( $item['end_date'] )->format( 'c' );
+        try {
+          $calendar_items[ $key ]['end_date'] = Utilities::get_mdp_day_end( $item['end_date'] )->format( 'c' );
+        } catch ( \InvalidArgumentException $e ) {
+          // Same rationale as start_date above.
+        }
       }
     }
 

--- a/includes/Utilities.php
+++ b/includes/Utilities.php
@@ -1211,14 +1211,47 @@ function wicket_sub_org_select_callback( $subscription ) {
    * @param \DateTimeZone $mdp_timezone MDP timezone.
    * @return \DateTime DateTime in the MDP timezone.
    */
+  /**
+   * Parse a date string into an MDP-timezone-aware DateTime.
+   *
+   * Bare `Y-m-d` dates are constructed directly in the MDP timezone to avoid
+   * a UTC round-trip that silently shifts the calendar day backward when
+   * MDP is behind UTC. Any other format (full ISO, `now`, relative strings)
+   * is parsed as-is and then relabeled into the MDP timezone, unchanged from
+   * the prior behavior. Malformed input that `DateTime` can't parse at all
+   * throws `\InvalidArgumentException` (instead of `DateTime`'s own
+   * `\Exception`), so callers on a public REST path can catch one specific
+   * type and fail with a normal 400 instead of a fatal 500.
+   *
+   * @param  string        $date_string   Date string to parse (bare date, ISO datetime, or relative format).
+   * @param  \DateTimeZone $mdp_timezone  Timezone to construct/relabel the date into.
+   *
+   * @throws \InvalidArgumentException  If $date_string can't be parsed as a date at all.
+   *
+   * @return \DateTime  Parsed date in the MDP timezone.
+   */
   private static function parse_as_mdp_date($date_string, \DateTimeZone $mdp_timezone)
   {
+    $date_string = (string) $date_string;
+
     if (preg_match('/^\d{4}-\d{2}-\d{2}$/', trim($date_string))) {
-      return new \DateTime($date_string, $mdp_timezone);
+      try {
+        return new \DateTime($date_string, $mdp_timezone);
+      } catch (\Throwable $e) {
+        // Fall through to the general parser below in case the bare-date
+        // pattern matched but the value is still somehow invalid.
+      }
     }
 
-    $mdp_date = new \DateTime($date_string);
-    return $mdp_date->setTimezone($mdp_timezone);
+    try {
+      $mdp_date = new \DateTime($date_string);
+      return $mdp_date->setTimezone($mdp_timezone);
+    } catch (\Throwable $e) {
+      // Normalize every unparseable-date failure (bare or general path) to one
+      // exception type, so REST call sites that want a clean 400 instead of a
+      // fatal 500 can catch a single, specific type.
+      throw new \InvalidArgumentException("Unparseable date string: {$date_string}", 0, $e);
+    }
   }
 
   /**

--- a/includes/Utilities.php
+++ b/includes/Utilities.php
@@ -1198,6 +1198,30 @@ function wicket_sub_org_select_callback( $subscription ) {
   }
 
   /**
+   * Parse a date string as a calendar date in the MDP timezone.
+   *
+   * A bare date (e.g. "2026-01-01", no time/offset) has no instant in time —
+   * it must be interpreted as already being that calendar day in the MDP
+   * timezone, not as a UTC midnight that then gets re-labeled into MDP time
+   * (which can roll the date backward/forward a day depending on offset).
+   * A string that does carry a time/offset (e.g. a full ISO datetime) is
+   * parsed normally and converted to the MDP timezone.
+   *
+   * @param string $date_string Date string to parse.
+   * @param \DateTimeZone $mdp_timezone MDP timezone.
+   * @return \DateTime DateTime in the MDP timezone.
+   */
+  private static function parse_as_mdp_date($date_string, \DateTimeZone $mdp_timezone)
+  {
+    if (preg_match('/^\d{4}-\d{2}-\d{2}$/', trim($date_string))) {
+      return new \DateTime($date_string, $mdp_timezone);
+    }
+
+    $mdp_date = new \DateTime($date_string);
+    return $mdp_date->setTimezone($mdp_timezone);
+  }
+
+  /**
    * Get the start of an MDP day (midnight) in UTC timezone.
    * This converts a date to the start of the day in the MDP timezone, then converts to UTC.
    *
@@ -1209,11 +1233,7 @@ function wicket_sub_org_select_callback( $subscription ) {
     // Get MDP timezone from environment variable, fallback to UTC
     $mdp_timezone = new \DateTimeZone($_ENV['WICKET_MSHIP_MDP_TIMEZONE'] ?? 'UTC');
 
-    // Create DateTime (timezone in string may override $mdp_timezone parameter)
-    $mdp_date = new \DateTime($date_string);
-
-    // Force timezone to MDP (handles cases where input string contains timezone info)
-    $mdp_date->setTimezone($mdp_timezone);
+    $mdp_date = self::parse_as_mdp_date($date_string, $mdp_timezone);
 
     // Set to start of day (midnight) in MDP timezone
     $mdp_date->setTime(0, 0, 0);
@@ -1234,11 +1254,7 @@ function wicket_sub_org_select_callback( $subscription ) {
     // Get MDP timezone from environment variable, fallback to UTC
     $mdp_timezone = new \DateTimeZone($_ENV['WICKET_MSHIP_MDP_TIMEZONE'] ?? 'UTC');
 
-    // Create DateTime (timezone in string may override $mdp_timezone parameter)
-    $mdp_date = new \DateTime($date_string);
-
-    // Force timezone to MDP (handles cases where input string contains timezone info)
-    $mdp_date->setTimezone($mdp_timezone);
+    $mdp_date = self::parse_as_mdp_date($date_string, $mdp_timezone);
 
     // Set to end of day (23:59:59) in MDP timezone
     $mdp_date->setTime(23, 59, 59);


### PR DESCRIPTION
## What
Calendar-cycle membership configs with multiple seasons (e.g. 2025/2026/2027) only kept a correct end-of-day time (23:59:59) on whichever season was most recently edited through the admin date picker. Every other season kept a legacy bare `Y-m-d` date (implicitly midnight) forever, and there was no way to fix a single season in isolation — the adjacency/overlap validators would reject the save.

## Why
Two compounding bugs:

1. **No server-side normalization on save.** The `cycle_data` REST field's `update_callback` persisted whatever `calendar_items` the client sent, verbatim. The admin UI's date picker only rewrites a season's `start_date`/`end_date` to a full end-of-day ISO timestamp when that specific season's picker is touched — untouched seasons keep whatever raw value they were created with (often a bare date from legacy data or import).

2. **`Utilities::get_mdp_day_start`/`get_mdp_day_end` mis-parsed bare dates.** A bare date like `"2026-01-01"` was parsed via `new \DateTime($date_string)` — using PHP's server default timezone (UTC) — and then *relabeled* into the MDP timezone (e.g. `America/Edmonton`, UTC-7) via `setTimezone()`. Relabeling an instant into a different timezone doesn't preserve the calendar day; it silently shifted the date backward by one day (e.g. midnight UTC on Jan 1 becomes 5pm Edmonton time on Dec 31).

Bug #2 is what made bug #1 impossible to work around by hand: correcting one season's end date to a proper end-of-day timestamp caused it to land ~5-7 hours into the *next* season's still-bare start date, which tripped both the "seasons must be within one day of each other" and "seasons must not overlap" validators — so the save was rejected with a 400, and the fix silently never landed.

## How
- Added `Utilities::parse_as_mdp_date()`: detects a bare `^\d{4}-\d{2}-\d{2}$` string and constructs the `DateTime` directly in the MDP timezone (no UTC round-trip), so the calendar day is preserved. Any input that isn't a bare date (full ISO datetime, offset, `"now"`, relative strings like `"+1 day"`) falls through to the original, unchanged code path.
- `get_mdp_day_start`/`get_mdp_day_end` now use `parse_as_mdp_date()` instead of parsing directly.
- Added `Membership_Post_Types::normalize_calendar_season_dates()`: normalizes every season's `start_date`/`end_date` to MDP day-start/day-end together, as one unit.
  - Wired into the `cycle_data` field's `sanitize_callback` (so the *stored* value is always normalized), and into `validate_callback` (on a local copy, so the adjacency/overlap checks compare like-with-like — WP core runs `validate_callback` before `sanitize_callback`, so normalization has to happen in both places to actually take effect before validation runs).
- Net effect: **any save of a calendar-cycle config self-heals all of its seasons**, including seasons the user didn't touch — no more requirement to hand-edit every adjacent season in the same sitting.

## Testing
- [x] Reproduced the original bug against a real config (3 seasons, 2 with legacy bare dates) via direct REST dispatch (`WP_REST_Server::dispatch`) — confirmed 400 `rest_invalid_param_calendar_dates` before the fix, on both "edit one season only" and even a full no-op resubmission of untouched data.
- [x] Verified `parse_as_mdp_date()` against every real input shape used elsewhere in the codebase (`now`, `+1 day`/`-1 day`, full ISO with `Z` suffix, full ISO with explicit offset, `Y-m-d H:i:s`) — confirmed byte-identical output to the old code path for every non-bare-date input (no behavior change outside the bug being fixed).
- [x] After the fix: same REST dispatch test returns `200`, and all three seasons persist as normalized, contiguous, MDP-timezone-aware ISO timestamps.
- [x] Confirmed a full no-op save of legacy bare-date data self-heals all seasons in one request, with no manual per-season editing required.
- [x] Manual QA: create a calendar-cycle config with 3+ seasons in the admin UI, save without editing anything, confirm all seasons show 23:59:59 end times.

**Known side effect (flagged, not fixed here):** `get_mdp_day_start`/`get_mdp_day_end` are also used to derive `membership_expires_at`/`membership_early_renew_at` for individual memberships (grace period and early-renewal window calculations) in `Membership_Config.php`, `Admin_Controller.php`, `Membership_Controller.php`, and `Import_Controller.php`, wherever those call sites build a bare `Y-m-d` string before calling in (e.g. `->format('Y-m-d')` on a modified date). Those bare-date call sites were also silently shifting a day backward under the old bug — this fix corrects them going forward, but does **not** backfill already-stored `membership_expires_at`/`membership_early_renew_at` values on existing memberships, which remain one day earlier than correct until the membership is next renewed or saved. No downstream logic was found that depends on the old off-by-one, so no functional regression is expected, but this is worth a heads-up to stakeholders before merge.

---
WWID-2136
Asana: https://app.asana.com/1/1138832104141584/project/1216279585352308/task/1216734621212188