### PR TITLE
fix(memberships): log external_id PATCH failures on member create #patch

### DIFF
--- a/includes/Membership_Controller.php
+++ b/includes/Membership_Controller.php
@@ -1331,7 +1331,27 @@ function get_item_data ( $other_data, $cart_item ) {
         ]);
       }
       //moved outside of conditional for merge membership functionality to work on update membership post meta
-      wicket_update_membership_external_id( $membership_wicket_uuid, $wicket_membership_type, $membership_post );
+      // external_id is what makes the MDP mark this membership as externally
+      // managed by WooCommerce (badge + locked dates). create_local_membership_record
+      // used to discard the PATCH return, so a failure was silent. Capture the
+      // result and log every failure so it surfaces (e.g. a 409 when external_id
+      // is already held by another membership_person) instead of leaving the
+      // membership unlinked (dates editable, no badge). No retry here: a
+      // permanent conflict cannot be retried away, and transient retry belongs
+      // in the HTTP client layer, not at this call site.
+      $external_id_result = wicket_update_membership_external_id( $membership_wicket_uuid, $wicket_membership_type, $membership_post );
+      if ( is_wp_error( $external_id_result ) ) {
+        Wicket()->log()->error(
+          'create_local_membership_record: external_id PATCH failed; membership will not show as Woo-managed and dates stay editable in MDP',
+          [
+            'source'                  => 'wicket-membership-plugin',
+            'membership_wicket_uuid'  => $membership_wicket_uuid,
+            'wicket_membership_type'  => $wicket_membership_type,
+            'membership_post_id'      => $membership_post,
+            'error'                   => $external_id_result->get_error_message(),
+          ]
+        );
+      }
 
     if( !empty( $membership['membership_parent_order_id'] )) {
       $order_meta = get_post_meta( $membership['membership_parent_order_id'], '_wicket_membership_'.$membership['membership_product_id'] );


### PR DESCRIPTION
## What
In `Membership_Controller::create_local_membership_record()`, capture the `wicket_update_membership_external_id()` result and log every failure via the base plugin logger. Previously the return was discarded, so a failed PATCH was silent.

## Why
A silent PATCH failure leaves the membership unlinked: no "managed by WooCommerce" badge and dates editable in the MDP. Verified on OBA staging (WWID-2194): all 12 memberships created 2026-08-05 had `external_id = NULL`; a backfill attempt showed each PATCH returns 409 "Record conflict" because `external_id` is already held by another `membership_person`. Root cause is MDP person-merge carry-over (the merge service reassigns membership_persons carrying `external_id`); that fix is tracked on the MDP side.

This PR makes those failures visible in the `wicket-membership-plugin` log so they surface instead of rotting silently.

## How
- Capture the result of `wicket_update_membership_external_id()`.
- On `WP_Error`, log via `Wicket()->log()->error()` (source `wicket-membership-plugin`) with uuid/type/post_id/error.
- No retry: the failure here is a permanent 409 (unique-index conflict), which a retry cannot resolve. Transient retry belongs in the HTTP client layer, not at this call site.

## Notes
- Targets the `WWID-1869` integration branch (v1.0.121, the deployed line). `main` (v1.0.113) is stale.
- Companion to the base-plugin helper logging PR (wicket-wp-base-plugin#27): that one logs inside the helper itself (all callers); this one logs at the memberships call site. Independent; either can merge first.
- Does not repair the 12 existing NULL records (needs a clear-then-set backfill after resolving the foreign holders) nor prevent recurrence (MDP merge-side fix). Both tracked separately.

## Testing
- [x] `php -l` clean.
- [ ] Reviewer: force a failed PATCH (e.g. an external_id already in use) and confirm a `wicket-membership-plugin` log line appears with uuid/type/post_id/error.

Task: https://app.asana.com/1/1138832104141584/task/1217204560329388