### PR TITLE
fix(dates): correct calendar season end + grace anchoring; add importer entry point (WWID-2196)

### DIFF
--- a/includes/Membership_Config.php
+++ b/includes/Membership_Config.php
@@ -234,11 +234,15 @@ class Membership_Config {
 
     foreach ( $seasons as $key => $season ) {
 
-      $start_dt = new \DateTime( $season['start_date'], new \DateTimeZone('UTC') );
-      $end_dt   = new \DateTime( $season['end_date'],   new \DateTimeZone('UTC') );
-
-      $seasons[ $key ]['start_date'] = Utilities::get_mdp_day_start( $start_dt->format('c') )->format('c');
-      $seasons[ $key ]['end_date']   = Utilities::get_mdp_day_end( $end_dt->format('c') )->format('c');
+      // Pass the raw season date straight to the day-boundary helpers. A bare
+      // Y-m-d season date (the legacy stored shape) is parsed in the MDP timezone
+      // by Utilities::parse_as_mdp_date(), so it resolves to the correct MDP day.
+      // The previous UTC round-trip (new DateTime(bare, UTC)->format('c')) emitted
+      // a tz-carrying string that relabeled into MDP time and shifted every season
+      // boundary one day backward for zones behind UTC. For already-normalized
+      // full-ISO season data this is an identity transform.
+      $seasons[ $key ]['start_date'] = Utilities::get_mdp_day_start( $season['start_date'] )->format('c');
+      $seasons[ $key ]['end_date']   = Utilities::get_mdp_day_end( $season['end_date'] )->format('c');
       // $seasons[ $key ]['active'] = $season['active'] === '1' ? true : false; // we don't this because it's already registered as boolean field
     }
 
@@ -417,25 +421,167 @@ class Membership_Config {
 
     $grace_period_in_days = $this->get_late_fee_window_days();
     if (!empty($grace_period_in_days)) {
-      // Parse end_date (which is in UTC) and add grace period days
-      $expires_at_utc = new \DateTime($dates['end_date'], new \DateTimeZone('UTC'));
-      $expires_date_string = $expires_at_utc->modify('+'.$grace_period_in_days.' days')->format('Y-m-d');
-      
-      // Get end of that day in MDP timezone, converted to UTC
+      // Anchor the grace window to the MDP calendar day of end_date, not the UTC
+      // instant. end_date is an MDP end-of-day (23:59:59) returned as UTC, which
+      // for a zone behind UTC lands on the NEXT UTC day; taking Y-m-d in UTC would
+      // start the grace window one day late.
+      $expires_date_string = $this->mdp_local_ymd( $dates['end_date'], '+' . $grace_period_in_days . ' days' );
       $dates['expires_at'] = Utilities::get_mdp_day_end($expires_date_string)->format('c');
     }
 
     $early_renewal_in_days = $this->get_renewal_window_days();
     if (!empty($early_renewal_in_days)) {
-      // Parse start_date (which is in UTC) and subtract early renewal days
-      $early_renew_at_utc = new \DateTime($dates['start_date'], new \DateTimeZone('UTC'));
-      $early_renew_date_string = $early_renew_at_utc->modify('-'.$early_renewal_in_days.' days')->format('Y-m-d');
-      
-      // Get start of that day in MDP timezone, converted to UTC
+      // Same MDP-day anchoring as the grace block. A zone AHEAD of UTC shifts a
+      // day-start backward in UTC, so taking Y-m-d in UTC loses a day here.
+      $early_renew_date_string = $this->mdp_local_ymd( $dates['start_date'], '-' . $early_renewal_in_days . ' days' );
       $dates['early_renew_at'] = Utilities::get_mdp_day_start($early_renew_date_string)->format('c');
     }
 
     return $dates;
+  }
+
+  /**
+   * Convert an ISO datetime to its Y-m-d in the MDP timezone, optionally after a
+   * relative modify ('+5 days', '-30 days'). Day boundaries returned by
+   * Utilities::get_mdp_day_* are MDP-local instants expressed as UTC; truncating
+   * them in UTC lands on the wrong calendar day for any zone offset from UTC.
+   * Converting back to the MDP timezone first recovers the intended local day.
+   *
+   * @param string $iso_date ISO 8601 datetime (typically a get_mdp_day_* result).
+   * @param string $modify   Optional relative modify applied in the MDP timezone.
+   * @return string Y-m-d in the MDP timezone.
+   */
+  private function mdp_local_ymd( $iso_date, $modify = '' ) {
+    $mdp_timezone = new \DateTimeZone( $_ENV['WICKET_MSHIP_MDP_TIMEZONE'] ?? 'UTC' );
+    $dt = new \DateTime( $iso_date );
+    $dt->setTimezone( $mdp_timezone );
+    if ( $modify !== '' ) {
+      $dt->modify( $modify );
+    }
+    return $dt->format( 'Y-m-d' );
+  }
+
+  /**
+   * Resolve the end date for a calendar-cycle membership whose term starts at
+   * $start_iso: the end of the configured season that contains the start, falling
+   * back to start + 1 year when no season covers it. Mirrors the matching loop in
+   * get_seasonal_end_date() but anchors to an explicit start instead of 'now'.
+   *
+   * @param string $start_iso ISO 8601 start datetime.
+   * @return string ISO 8601 end datetime (MDP end-of-day, expressed as UTC).
+   */
+  private function season_end_containing( $start_iso ) {
+    $mdp_timezone = new \DateTimeZone( $_ENV['WICKET_MSHIP_MDP_TIMEZONE'] ?? 'UTC' );
+    $seasons = $this->get_calendar_seasons();
+
+    $membership_start_dt = Utilities::get_mdp_day_start( $start_iso );
+    $membership_start_dt->setTimezone( $mdp_timezone );
+
+    // Default end when no configured season covers the start.
+    $selected_end_dt = clone $membership_start_dt;
+    $selected_end_dt->modify( '+1 year' );
+
+    if ( is_array( $seasons ) ) {
+      foreach ( $seasons as $season ) {
+        $season_start_mdp = ( new \DateTime( $season['start_date'] ) )->setTimezone( $mdp_timezone );
+        $season_end_mdp   = ( new \DateTime( $season['end_date'] ) )->setTimezone( $mdp_timezone );
+        if ( $membership_start_dt >= $season_start_mdp && $membership_start_dt <= $season_end_mdp ) {
+          $selected_end_dt = $season_end_mdp;
+        }
+      }
+    }
+
+    return $selected_end_dt->setTimezone( new \DateTimeZone( 'UTC' ) )->format( 'c' );
+  }
+
+  /**
+   * Compute the full membership date set anchored to an explicit start date.
+   *
+   * The importer's entry point. The importer knows the real start (the member's
+   * admit date) but is NOT a renewal, so it must not call get_membership_dates():
+   * that method splits new vs renewal on empty($membership) and builds every date
+   * off 'now' for a new membership, ignoring any passed membership_starts_at, and
+   * a non-empty array selects the renewal branch. This method takes the start as
+   * a direct argument and reuses the same anniversary / seasonal / grace /
+   * early-renew math (Utilities::get_mdp_day_*, get_calendar_seasons,
+   * get_late_fee_window_days, get_renewal_window_days), so the day-boundary engine
+   * stays in one place. Existing callers of get_membership_dates() are unchanged.
+   *
+   * @param string $starts_iso Start date (Y-m-d or ISO 8601).
+   * @return array{start_date:string,end_date:string,expires_at:string,early_renew_at:string}
+   */
+  public function get_membership_dates_for_start( $starts_iso ) {
+    $cycle_data = $this->get_cycle_data();
+
+    $dates = [];
+    $dates['start_date'] = Utilities::get_mdp_day_start( $starts_iso )->format( 'c' );
+
+    if ( $cycle_data['cycle_type'] === 'anniversary' ) {
+      $period_count = ! empty( $cycle_data['anniversary_data']['period_count'] ) && is_numeric( $cycle_data['anniversary_data']['period_count'] )
+        ? $cycle_data['anniversary_data']['period_count'] : 1;
+      $period_type = ! in_array( $cycle_data['anniversary_data']['period_type'], [ 'year', 'month', 'day' ], true )
+        ? 'year' : $cycle_data['anniversary_data']['period_type'];
+
+      $the_end_date = date( 'Y-m-d', strtotime( $dates['start_date'] . '+' . $period_count . ' ' . $period_type ) );
+      if ( in_array( $period_type, [ 'year', 'month' ], true )
+        && ! empty( $cycle_data['anniversary_data']['align_end_dates_enabled'] )
+        && $cycle_data['anniversary_data']['align_end_dates_enabled'] !== false ) {
+        switch ( $cycle_data['anniversary_data']['align_end_dates_type'] ) {
+          case 'first-day-of-month':
+            $the_end_date = date( 'Y-m-1', strtotime( $dates['start_date'] . '+' . $period_count . ' ' . $period_type ) );
+            break;
+          case '15th-of-month':
+            $the_end_date = date( 'Y-m-15', strtotime( $dates['start_date'] . '+' . $period_count . ' ' . $period_type ) );
+            break;
+          case 'last-day-of-month':
+            $the_end_date = date( 'Y-m-t', strtotime( $dates['start_date'] . '+' . $period_count . ' ' . $period_type ) );
+            break;
+        }
+      }
+      $dates['end_date'] = Utilities::get_mdp_day_end( $the_end_date )->format( 'c' );
+    } else {
+      $dates['end_date'] = $this->season_end_containing( $dates['start_date'] );
+    }
+
+    $grace_period_in_days = $this->get_late_fee_window_days();
+    if ( ! empty( $grace_period_in_days ) ) {
+      $expires_date_string = $this->mdp_local_ymd( $dates['end_date'], '+' . $grace_period_in_days . ' days' );
+      $dates['expires_at'] = Utilities::get_mdp_day_end( $expires_date_string )->format( 'c' );
+    }
+
+    $early_renewal_in_days = $this->get_renewal_window_days();
+    if ( ! empty( $early_renewal_in_days ) ) {
+      $early_renew_date_string = $this->mdp_local_ymd( $dates['start_date'], '-' . $early_renewal_in_days . ' days' );
+      $dates['early_renew_at'] = Utilities::get_mdp_day_start( $early_renew_date_string )->format( 'c' );
+    }
+
+    return $dates;
+  }
+
+  /**
+   * Return the start date (Y-m-d) of the configured calendar season that contains
+   * $iso, or null when no season covers it. Exposed so importers that want to pin
+   * a membership start to the season start (e.g. Jan 1 of the term year) can do so
+   * without reimplementing the season lookup.
+   *
+   * @param string $iso ISO 8601 or Y-m-d date.
+   * @return string|null Y-m-d season start, or null.
+   */
+  public function get_season_start_for_date( $iso ) {
+    $mdp_timezone = new \DateTimeZone( $_ENV['WICKET_MSHIP_MDP_TIMEZONE'] ?? 'UTC' );
+    $seasons = $this->get_calendar_seasons();
+    if ( ! is_array( $seasons ) ) {
+      return null;
+    }
+    $target = ( new \DateTime( $iso ) )->setTimezone( $mdp_timezone );
+    foreach ( $seasons as $season ) {
+      $season_start_mdp = ( new \DateTime( $season['start_date'] ) )->setTimezone( $mdp_timezone );
+      $season_end_mdp   = ( new \DateTime( $season['end_date'] ) )->setTimezone( $mdp_timezone );
+      if ( $target >= $season_start_mdp && $target <= $season_end_mdp ) {
+        return $season_start_mdp->format( 'Y-m-d' );
+      }
+    }
+    return null;
   }
 
   public function is_multitier_renewal() {

--- a/includes/Membership_Controller.php
+++ b/includes/Membership_Controller.php
@@ -1186,13 +1186,44 @@ function get_item_data ( $other_data, $cart_item ) {
       }
       if( is_wp_error( $response ) ) {
         $this->error_message = $response->get_error_message( 'wicket_api_error' );
-        //$this->surface_error();
+        // WWID-2199: surface the real MDP error so callers that do not run in a
+        // checkout context (the bulk importer, admin tools) can see WHY the
+        // assign failed instead of only observing an empty UUID. The importer's
+        // adapter reads this via get_error_message(); wc_log_mship_error() also
+        // lands it in wc-logs for QA (wc_add_notice never fires here).
+        Utilities::wc_log_mship_error( [
+          'Membership_Controller::create_mdp_record MDP assign failed',
+          [
+            'person_uuid'          => $membership['person_uuid'] ?? '',
+            'membership_type'      => $membership['membership_type'] ?? '',
+            'membership_tier_uuid' => $membership['membership_tier_uuid'] ?? '',
+            'membership_starts_at' => $membership['membership_starts_at'] ?? '',
+            'membership_ends_at'   => $membership['membership_ends_at'] ?? '',
+            'error'                => $this->error_message,
+          ],
+        ] );
         $membership_wicket_uuid = '';
       } else {
         $membership_wicket_uuid = $response['data']['id'];
       }
     }
     return $membership_wicket_uuid;
+  }
+
+  /**
+   * The last MDP error message stashed by create_mdp_record() / update_mdp_record().
+   *
+   * WWID-2199: create_mdp_record() returns '' on failure and previously had no
+   * way for a non-checkout caller (the bulk importer, admin tools) to read WHY
+   * the MDP rejected the assign. Public read-only accessor so the importer can
+   * surface the real validation error (e.g. a 422 for ends_at <= starts_at)
+   * instead of a generic "returned no UUID". The value is also wc_log_mship_
+   * error()d inside create_mdp_record() so it is visible in wc-logs regardless.
+   *
+   * @return string
+   */
+  public function get_error_message() {
+    return $this->error_message;
   }
 
   /**


### PR DESCRIPTION
## What
Fixes a one-day drift on calendar-cycle membership dates and the grace/early-renew windows for MDP zones behind UTC (for example America/New_York), and adds an admit-anchored date entry point for the importer. OBA importer date bug, WWID-2196.

## Why
Five date defects shared one neighborhood. `ad8c900` (PR #57) already fixed the bare-date timezone shift in `Utilities` (defect A). This PR fixes the remaining live ones.

- **B** `Membership_Config::get_calendar_seasons()` round-tripped bare `Y-m-d` season dates through a UTC `DateTime` before the day-boundary call. The tz-carrying string it produced relabeled into the MDP timezone and shifted every season boundary back one day, so a Dec 31 season end displayed as Dec 30. This was the reported end-date symptom.
- **C** `get_membership_dates()` derived `expires_at` and `early_renew_at` by taking `Y-m-d` off the UTC instant, which behind UTC lands on the next day. New `mdp_local_ymd()` converts back to the MDP timezone first.

B and C cancel for calendar `expires_at` today, so they ship together in this one commit.

## Additive entry point
Adds `Membership_Config::get_membership_dates_for_start($starts_iso)` and `get_season_start_for_date($iso)`. The importer knows the real start (the admit date) but is not a renewal; `get_membership_dates()` builds new memberships off today and ignores any passed start. The new method anchors the full date set to an explicit start without touching the `empty($membership)` new/renewal discriminator. Existing callers are unchanged.

Rationale and rejected alternatives (inline the math in the importer; teach `get_membership_dates` to honor `membership_starts_at`) are in ADR A0006.

## Verification
Empirical PHP against OBA config 1629 (calendar, MDP America/New_York):
- `get_membership_dates_for_start('2026-08-08')` -> start `2026-08-08`, end `2026-12-31` (was `2026-12-30`), expires `2028-06-30`, early_renew `2026-05-23`.
- Cross-year admit `2027-06-15` -> end `2027-12-31` (the old now-anchored path gave `2026`).

`php -l` clean. No existing tests touched.

## Companions
- Importer: switches to `get_membership_dates_for_start` (guarded by `method_exists`), landed direct to `main`.
- OBA theme: `WICKET_OBA_IMPORT_START_MODE` (default `admit`), on `stage`.
- Atlas: `quirks/membership-date-tz-anchoring.md`, `decisions/A0006-admit-anchored-membership-date-entry-point.md`.

## Notes
- Stored membership meta does not self-heal. Affected records need a re-import once this deploys.
- No regression tests added yet (the `qa/` suite is a separate repo). Happy to add before merge.