### PR TITLE
Guard external_id assignment against silent collisions

### DIFF
--- a/includes/Admin_Controller.php
+++ b/includes/Admin_Controller.php
@@ -182,7 +182,7 @@ class Admin_Controller {
       if($membership_post_data['membership_type'] == 'organization') {
         $wicket_membership_type = 'organization_memberships';
       }
-      wicket_update_membership_external_id( $membership['membership_wicket_uuid'], $wicket_membership_type, $membership_post_id );
+      $Membership_Controller->assign_membership_external_id( $membership['membership_wicket_uuid'], $wicket_membership_type, $membership_post_id );
 
       do_action('wicket_membership_created_mdp', $membership_post_data);
       $response_array['success'] = 'Pending membership activated successfully.';
@@ -1015,7 +1015,7 @@ class Admin_Controller {
 
           $single_merged_wicket_membership_uuid = $response1['data']['id'];
           update_post_meta( $membership_post_id, 'membership_wicket_uuid', $single_merged_wicket_membership_uuid);
-          wicket_update_membership_external_id( $single_merged_wicket_membership_uuid, 'person_memberships', $membership_post_id );
+          (new Membership_Controller)->assign_membership_external_id( $single_merged_wicket_membership_uuid, 'person_memberships', $membership_post_id );
       }
 
       $orig_user_id = is_numeric( $record_id ) ? $record_id : get_post_meta( $membership_post_id, 'user_id', true);
@@ -1534,10 +1534,7 @@ class Admin_Controller {
 
     $membership_type = $old_customer_meta_array['membership_type'] == 'individual' ? 'person_memberships' : 'organization_memberships';
     // Update the new wicket membership with the new external ID
-    $response_external_id = wicket_update_membership_external_id( $membership_wicket_uuid, $membership_type, $new_post_id );
-    if ( is_wp_error( $response_external_id ) ) {
-      Utilities::wc_log_mship_error( [ 'Transfer membership - Set external ID failed.', 'wicket_api_error' => $response_external_id->get_error_message( 'wicket_api_error' ), $membership_wicket_uuid, $membership_type, $new_post_id, $old_customer_meta_array['membership_type'] ]);
-    }
+    (new Membership_Controller)->assign_membership_external_id( $membership_wicket_uuid, $membership_type, $new_post_id );
 
     $meta_data = [
       'membership_starts_at' =>  $old_customer_meta_array['membership_starts_at'],

--- a/includes/Admin_Controller.php
+++ b/includes/Admin_Controller.php
@@ -178,6 +178,8 @@ class Admin_Controller {
       $membership_post_data = Helper::get_post_meta( $membership_post_id );
 
       //update wicket wxternal_id
+      // Return value ignored on purpose: the method flags failures via post meta
+      // (_collision/_failed) and wc-logs, and this flow must not abort on a failed link.
       $wicket_membership_type = 'person_memberships';
       if($membership_post_data['membership_type'] == 'organization') {
         $wicket_membership_type = 'organization_memberships';
@@ -1015,6 +1017,8 @@ class Admin_Controller {
 
           $single_merged_wicket_membership_uuid = $response1['data']['id'];
           update_post_meta( $membership_post_id, 'membership_wicket_uuid', $single_merged_wicket_membership_uuid);
+          // Return value ignored on purpose: failures are flagged via post meta
+          // (_collision/_failed) and wc-logs; the merge itself must complete.
           (new Membership_Controller)->assign_membership_external_id( $single_merged_wicket_membership_uuid, 'person_memberships', $membership_post_id );
       }
 
@@ -1534,6 +1538,8 @@ class Admin_Controller {
 
     $membership_type = $old_customer_meta_array['membership_type'] == 'individual' ? 'person_memberships' : 'organization_memberships';
     // Update the new wicket membership with the new external ID
+    // Return value ignored on purpose: failures are flagged via post meta
+    // (_collision/_failed) and wc-logs; the owner change must complete regardless.
     (new Membership_Controller)->assign_membership_external_id( $membership_wicket_uuid, $membership_type, $new_post_id );
 
     $meta_data = [

--- a/includes/Membership_Controller.php
+++ b/includes/Membership_Controller.php
@@ -1482,6 +1482,8 @@ function get_item_data ( $other_data, $cart_item ) {
         ]);
       }
       //moved outside of conditional for merge membership functionality to work on update membership post meta
+      // Return value ignored on purpose: failures are flagged via post meta
+      // (_collision/_failed) and wc-logs; local record creation must complete.
       $this->assign_membership_external_id( $membership_wicket_uuid, $wicket_membership_type, $membership_post );
 
     if( !empty( $membership['membership_parent_order_id'] )) {

--- a/includes/Membership_Controller.php
+++ b/includes/Membership_Controller.php
@@ -1227,6 +1227,87 @@ function get_item_data ( $other_data, $cart_item ) {
   }
 
   /**
+   * Assign the WP membership post ID as the MDP external_id, with a pre-flight
+   * collision check.
+   *
+   * external_id is the WP post ID and the MDP holds a unique index on it per
+   * membership type. When another membership already owns that ID, the PATCH
+   * returns an opaque 409 and external_id stays NULL silently. This method
+   * detects the collision before the PATCH when the base plugin helper is
+   * available, reports it with the owning record, and flags the post either way
+   * so the broken state is visible in WP admin and wc-logs instead of silent.
+   *
+   * @param string $membership_wicket_uuid MDP membership id.
+   * @param string $wicket_membership_type person_memberships|organization_memberships.
+   * @param int    $membership_post_id     WP membership post ID (the external_id).
+   * @return bool True on success, false on collision or failure.
+   */
+  public function assign_membership_external_id( $membership_wicket_uuid, $wicket_membership_type, $membership_post_id ) {
+    $logger = wc_get_logger();
+    $log_context = [ 'source' => 'wicket-memberships' ];
+
+    // Pre-flight: detect an external_id already owned by a different membership.
+    // The helper ships in wicket-wp-base-plugin; guard with function_exists so
+    // this plugin stays safe if a site runs an older base plugin.
+    if ( function_exists( 'wicket_get_membership_by_external_id' ) ) {
+      $owner = wicket_get_membership_by_external_id( $membership_post_id, $wicket_membership_type );
+
+      if ( ! is_wp_error( $owner ) && ! empty( $owner['id'] ) && $owner['id'] !== $membership_wicket_uuid ) {
+        $owner_id = $owner['id'];
+        $logger->error(
+          sprintf(
+            'Membership external_id collision: WP post %1$s already owned by %2$s/%3$s (target %4$s). Skipping external_id PATCH; post %1$s left without an MDP link.',
+            $membership_post_id,
+            $wicket_membership_type,
+            $owner_id,
+            $membership_wicket_uuid
+          ),
+          $log_context
+        );
+        update_post_meta( $membership_post_id, '_wicket_membership_external_id_collision', [
+          'external_id' => $membership_post_id,
+          'type'        => $wicket_membership_type,
+          'owner'       => $owner_id,
+          'target'      => $membership_wicket_uuid,
+          'time'        => current_time( 'mysql', true ),
+        ] );
+        return false;
+      }
+    }
+
+    // No collision (or pre-flight unavailable): PATCH and act on the result.
+    $result = wicket_update_membership_external_id( $membership_wicket_uuid, $wicket_membership_type, $membership_post_id );
+
+    if ( is_wp_error( $result ) ) {
+      // The base helper already logged the API error; flag the post too so the
+      // broken state is visible at the WP layer, not only in wc-logs.
+      $logger->error(
+        sprintf(
+          'Membership external_id PATCH failed for WP post %1$s (target %2$s/%3$s): %4$s',
+          $membership_post_id,
+          $wicket_membership_type,
+          $membership_wicket_uuid,
+          $result->get_error_message()
+        ),
+        $log_context
+      );
+      update_post_meta( $membership_post_id, '_wicket_membership_external_id_failed', [
+        'external_id' => $membership_post_id,
+        'type'        => $wicket_membership_type,
+        'target'      => $membership_wicket_uuid,
+        'error'       => $result->get_error_message(),
+        'time'        => current_time( 'mysql', true ),
+      ] );
+      return false;
+    }
+
+    // Success: clear stale flags from a prior failed attempt.
+    delete_post_meta( $membership_post_id, '_wicket_membership_external_id_failed' );
+    delete_post_meta( $membership_post_id, '_wicket_membership_external_id_collision' );
+    return true;
+  }
+
+  /**
    * Check if MDP Membership Record already exists
    */
   private function check_mdp_membership_record_exists( $membership ) {
@@ -1401,7 +1482,7 @@ function get_item_data ( $other_data, $cart_item ) {
         ]);
       }
       //moved outside of conditional for merge membership functionality to work on update membership post meta
-      wicket_update_membership_external_id( $membership_wicket_uuid, $wicket_membership_type, $membership_post );
+      $this->assign_membership_external_id( $membership_wicket_uuid, $wicket_membership_type, $membership_post );
 
     if( !empty( $membership['membership_parent_order_id'] )) {
       $order_meta = get_post_meta( $membership['membership_parent_order_id'], '_wicket_membership_'.$membership['membership_product_id'] );


### PR DESCRIPTION
## What
Routes every external_id write through a new `Membership_Controller::assign_membership_external_id()` method:
- `Membership_Controller.php` (importer create path)
- `Admin_Controller.php` (admin activation, membership merge, membership transfer)

## How
1. Pre-flight: if `wicket_get_membership_by_external_id()` (base plugin) finds another membership already owns the external_id, log the owner UUID, set `_wicket_membership_external_id_collision` post meta, and skip the PATCH.
2. PATCH: capture the return. On `WP_Error`, log and set `_wicket_membership_external_id_failed` post meta.
3. Success: clear stale flags.

## Why
The importer discarded the PATCH return, so a 409 left `external_id` NULL with no signal (the OBA NULL external_id incident). This surfaces any failure at the WP layer regardless of how clearly the MDP reports the error, so a dropped external_id can never go invisible again. The transfer path already logged failures; it now also gets the pre-flight and the post flag.

## Compatibility
The pre-flight is guarded with `function_exists`, so this plugin stays safe on a site running an older base plugin. The return-capture half works standalone, so this PR is valuable even if it lands before the base plugin PR.

## Base branch
Targets `feature/users-multi-tier-renewal-subscriptions-merged` per the stack `AGENTS.md` dev caveat; `main` holds old code in this repo.

## Related
- Base plugin helper: `industrialdev/wicket-wp-base-plugin` PR #30
- Tests: `industrialdev/wicket-warden` PR #7
- Asana: https://app.asana.com/1/1138832104141584/project/1211856276706882/task/1217204560329388